### PR TITLE
Upgrade to TrustGraph 2.4.29 with auto-generated secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,21 @@ This will allow you to access Grafana and the Workbench UI from your local
 browser using `http://localhost:3000` and `http://localhost:8888`
 respectively.
 
+The IAM bootstrap token and Grafana admin password are auto-generated
+by Pulumi.  After deployment, retrieve them with:
+```
+pulumi stack output iamToken --show-secrets
+pulumi stack output grafanaPassword --show-secrets
+```
+
+Login to Grafana with username `admin` and the password from the command
+above.
+
+To use the TrustGraph API with authentication:
+```
+export TRUSTGRAPH_TOKEN=$(pulumi stack output iamToken --show-secrets)
+```
+
 
 ## Deploy
 
@@ -165,5 +180,5 @@ The AI model specified in the config.json should match the model in the
 AI endpoint hostname specified in the Pulumi config.
 
 ```
-./update-config  scw-k8s 2.2.24
+./update-config scw-k8s 2.4.29
 ```

--- a/pulumi/__tests__/infrastructure.test.ts
+++ b/pulumi/__tests__/infrastructure.test.ts
@@ -123,12 +123,15 @@ spec:
         
         // Test Kubernetes secrets
         const secrets = createdResources.filter(r => r.type === "kubernetes:core/v1:Secret");
-        const gatewaySecret = secrets.find(s => s.inputs.metadata?.name === "gateway-secret");
+        const iamSecret = secrets.find(s => s.inputs.metadata?.name === "iam-bootstrap-token");
+        const grafanaSecret = secrets.find(s => s.inputs.metadata?.name === "grafana-secret");
         const aiSecret = secrets.find(s => s.inputs.metadata?.name === "openai-credentials");
-        
-        expect(gatewaySecret).toBeDefined();
+
+        expect(iamSecret).toBeDefined();
+        expect(grafanaSecret).toBeDefined();
         expect(aiSecret).toBeDefined();
-        expect(gatewaySecret?.inputs.metadata?.namespace).toBe("trustgraph");
+        expect(iamSecret?.inputs.metadata?.namespace).toBe("trustgraph");
+        expect(grafanaSecret?.inputs.metadata?.namespace).toBe("trustgraph");
         expect(aiSecret?.inputs.metadata?.namespace).toBe("trustgraph");
         
         // console.log(`Created ${createdResources.length} resources:`, createdResources.map(r => r.type));

--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -2,9 +2,27 @@
 import * as scaleway from '@pulumiverse/scaleway';
 import * as pulumi from '@pulumi/pulumi';
 import * as k8s from '@pulumi/kubernetes';
+import * as random from '@pulumi/random';
 import * as fs from 'fs';
 
 import { prefix, region, nodeSize, nodeCount } from './config';
+
+const iamBootstrapToken = new random.RandomPassword(
+    "iam-bootstrap-token",
+    {
+        length: 32,
+        special: false,
+    },
+);
+
+const grafanaAdminPassword = new random.RandomPassword(
+    "grafana-admin-password",
+    {
+        length: 16,
+        special: true,
+        overrideSpecial: "!@#$%^&*",
+    },
+);
 
 // Scaleway provider, allows setting the default region
 const provider = new scaleway.Provider(
@@ -141,31 +159,29 @@ const appDeploy = new k8s.yaml.v2.ConfigGroup(
     { provider: k8sProvider }
 );
 
-// Generate an (empty) gateway secret - no authentication
-const gatewaySecret = new k8s.core.v1.Secret(
-    "gateway-secret",
+const iamSecret = new k8s.core.v1.Secret(
+    "iam-bootstrap-token",
     {
         metadata: {
-            name: "gateway-secret",
+            name: "iam-bootstrap-token",
             namespace: "trustgraph"
         },
         stringData: {
-            "gateway-secret": ""
+            "token": pulumi.interpolate`tg_${iamBootstrapToken.result}`,
         },
     },
     { provider: k8sProvider, dependsOn: appDeploy }
 );
 
-// Generate an (empty) MCP server secret - no authentication
-const mcpServerSecret = new k8s.core.v1.Secret(
-    "mcp-server-secret",
+const grafanaSecret = new k8s.core.v1.Secret(
+    "grafana-secret",
     {
         metadata: {
-            name: "mcp-server-secret",
+            name: "grafana-secret",
             namespace: "trustgraph"
         },
         stringData: {
-            "mcp-server-secret": ""
+            "password": grafanaAdminPassword.result,
         },
     },
     { provider: k8sProvider, dependsOn: appDeploy }
@@ -186,4 +202,8 @@ const endpointSecret = new k8s.core.v1.Secret(
     },
     { provider: k8sProvider, dependsOn: appDeploy }
 );
+
+export const iamToken = pulumi.interpolate`tg_${iamBootstrapToken.result}`;
+
+export const grafanaPassword = grafanaAdminPassword.result;
 

--- a/resources.yaml
+++ b/resources.yaml
@@ -28,57 +28,6 @@ items:
   kind: Deployment
   metadata:
     labels:
-      app: agent-manager
-    name: agent-manager
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: agent-manager
-    template:
-      metadata:
-        labels:
-          app: agent-manager
-      spec:
-        containers:
-        - command:
-          - agent-orchestrator
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: agent-manager
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 256M
-            requests:
-              cpu: '0.1'
-              memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: agent-manager
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: agent-manager
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
       app: api-gateway
     name: api-gateway
     namespace: trustgraph
@@ -105,13 +54,7 @@ items:
           - '8088'
           - --log-level
           - INFO
-          env:
-          - name: GATEWAY_SECRET
-            valueFrom:
-              secretKeyRef:
-                key: gateway-secret
-                name: gateway-secret
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
+          image: docker.io/trustgraph/trustgraph-flow:2.4.29
           name: api-gateway
           ports:
           - containerPort: 8088
@@ -123,9 +66,7 @@ items:
             requests:
               cpu: '0.1'
               memory: 768M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
+        enableServiceLinks: false
         volumes: []
 - apiVersion: v1
   kind: Service
@@ -134,12 +75,12 @@ items:
     namespace: trustgraph
   spec:
     ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
     - name: api
       port: 8088
       targetPort: 8088
+    - name: metrics
+      port: 8000
+      targetPort: 8000
     selector:
       app: api-gateway
 - apiVersion: v1
@@ -174,8 +115,8 @@ items:
         containers:
         - env:
           - name: JVM_OPTS
-            value: -Xms500M -Xmx500M -Dcassandra.skip_wait_for_gossip_to_settle=0
-          image: docker.io/cassandra:5.0.6
+            value: -Xms300M -Xmx300M -Dcassandra.skip_wait_for_gossip_to_settle=0
+          image: docker.io/cassandra:5.0.8
           name: cassandra
           ports:
           - containerPort: 9042
@@ -183,16 +124,16 @@ items:
           resources:
             limits:
               cpu: '1.0'
-              memory: 2000M
+              memory: 1000M
             requests:
               cpu: '0.5'
-              memory: 2000M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
+              memory: 1000M
           volumeMounts:
           - mountPath: /var/lib/cassandra
             name: cassandra
+        enableServiceLinks: false
+        securityContext:
+          fsGroup: 999
         volumes:
         - name: cassandra
           persistentVolumeClaim:
@@ -209,1700 +150,206 @@ items:
       targetPort: 9042
     selector:
       app: cassandra
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: chunker
-    name: chunker
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: chunker
-    template:
-      metadata:
-        labels:
-          app: chunker
-      spec:
-        containers:
-        - command:
-          - chunker-recursive
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --chunk-size
-          - '2000'
-          - --chunk-overlap
-          - '50'
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: chunker
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: chunker
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: chunker
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: config-svc
-    name: config-svc
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: config-svc
-    template:
-      metadata:
-        labels:
-          app: config-svc
-      spec:
-        containers:
-        - command:
-          - config-svc
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: config-svc
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: config-svc
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: config-svc
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: ddg-mcp-server
-    name: ddg-mcp-server
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: ddg-mcp-server
-    template:
-      metadata:
-        labels:
-          app: ddg-mcp-server
-      spec:
-        containers:
-        - image: docker.io/trustgraph/ddg-mcp-server:0.1.0
-          name: ddg-mcp-server
-          ports:
-          - containerPort: 9870
-            hostPort: 9870
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 256M
-            requests:
-              cpu: '0.1'
-              memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: ddg-mcp-server
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: mcp
-      port: 9870
-      targetPort: 9870
-    selector:
-      app: ddg-mcp-server
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: document-decoder
-    name: document-decoder
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: document-decoder
-    template:
-      metadata:
-        labels:
-          app: document-decoder
-      spec:
-        containers:
-        - command:
-          - universal-decoder
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-unstructured:2.2.24
-          name: document-decoder
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 512M
-            requests:
-              cpu: '0.1'
-              memory: 512M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: document-decoder
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: document-decoder
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: document-embeddings
-    name: document-embeddings
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: document-embeddings
-    template:
-      metadata:
-        labels:
-          app: document-embeddings
-      spec:
-        containers:
-        - command:
-          - document-embeddings
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: document-embeddings
-          resources:
-            limits:
-              cpu: '1.0'
-              memory: 512M
-            requests:
-              cpu: '0.5'
-              memory: 512M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: document-embeddings
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: document-embeddings
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: document-rag
-    name: document-rag
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: document-rag
-    template:
-      metadata:
-        labels:
-          app: document-rag
-      spec:
-        containers:
-        - command:
-          - document-rag
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --doc-limit
-          - '20'
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: document-rag
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: document-rag
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: document-rag
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: embeddings
-    name: embeddings
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: embeddings
-    template:
-      metadata:
-        labels:
-          app: embeddings
-      spec:
-        containers:
-        - command:
-          - embeddings-fastembed
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --concurrency
-          - '1'
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: embeddings
-          resources:
-            limits:
-              cpu: '2.0'
-              memory: 600M
-            requests:
-              cpu: '1.0'
-              memory: 600M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: embeddings
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: embeddings
 - apiVersion: v1
   data:
-    garage.toml: 'metadata_dir = "/var/lib/garage/meta"
-
-      data_dir = "/var/lib/garage/data"
-
-
-      db_engine = "lmdb"
-
-
-      replication_factor = 1
-
-
-      compression_level = 1
-
-
-      rpc_bind_addr = "[::]:3901"
-
-      rpc_public_addr = "[::]:3901"
-
-      rpc_secret = "bbba746a9e289bad64a9e7a36a4299dac8d6e0b8cc2a6c2937fe756df4492008"
-
-
-      [s3_api]
-
-      s3_region = "garage"
-
-      api_bind_addr = "[::]:3900"
-
-      root_domain = ".s3.garage.local"
-
-
-      [s3_web]
-
-      bind_addr = "[::]:3902"
-
-      root_domain = ".web.garage.local"
-
-      index = "index.html"
-
-
-      [k2v_api]
-
-      api_bind_addr = "[::]:3904"
-
-
-      [admin]
-
-      api_bind_addr = "[::]:3903"
-
-      admin_token = "batts-rockhearted-unpartially"
-
-      '
+    launch.yaml: "\"processors\":\n- \"class\": \"trustgraph.librarian.Processor\"\
+      \n  \"params\":\n    \"id\": \"librarian\"\n    \"object_store_access_key\"\
+      : \"GK000000000000000000000001\"\n    \"object_store_endpoint\": \"garage:3900\"\
+      \n    \"object_store_region\": \"garage\"\n    \"object_store_secret_key\":\
+      \ \"b171f00be9be4c32c734f4c05fe64c527a8ab5eb823b376cfa8c2531f70fc427\"\n   \
+      \ \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
+      \n- \"class\": \"trustgraph.config.service.Processor\"\n  \"params\":\n    \"\
+      id\": \"config-svc\"\n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\"\
+      : \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.flow.service.Processor\"\
+      \n  \"params\":\n    \"id\": \"flow-svc\"\n    \"pubsub_backend\": \"pulsar\"\
+      \n    \"pulsar_admin_url\": \"http://pulsar:8080\"\n    \"pulsar_host\": \"\
+      pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.cores.service.Processor\"\n\
+      \  \"params\":\n    \"id\": \"knowledge\"\n    \"pubsub_backend\": \"pulsar\"\
+      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.storage.knowledge.store.Processor\"\
+      \n  \"params\":\n    \"id\": \"kg-store\"\n    \"pubsub_backend\": \"pulsar\"\
+      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.metering.Processor\"\
+      \n  \"params\":\n    \"id\": \"metering\"\n    \"pubsub_backend\": \"pulsar\"\
+      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.metering.Processor\"\
+      \n  \"params\":\n    \"id\": \"metering-rag\"\n    \"pubsub_backend\": \"pulsar\"\
+      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.iam.service.Processor\"\
+      \n  \"params\":\n    \"bootstrap_mode\": \"token\"\n    \"id\": \"iam-svc\"\n\
+      \    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
+      \n- \"class\": \"trustgraph.bootstrap.bootstrapper.Processor\"\n  \"params\"\
+      :\n    \"id\": \"bootstrap\"\n    \"initialisers\":\n    - \"class\": \"trustgraph.bootstrap.initialisers.PulsarTopology\"\
+      \n      \"flag\": \"v1\"\n      \"name\": \"pulsar-topology\"\n      \"params\"\
+      :\n        \"admin_url\": \"http://pulsar:8080\"\n    - \"class\": \"trustgraph.bootstrap.initialisers.TemplateSeed\"\
+      \n      \"flag\": \"v1\"\n      \"name\": \"template-seed\"\n      \"params\"\
+      :\n        \"config_file\": \"/etc/trustgraph/template/config.json\"\n     \
+      \   \"overwrite\": false\n    - \"class\": \"trustgraph.bootstrap.initialisers.WorkspaceInit\"\
+      \n      \"flag\": \"v1\"\n      \"name\": \"default-workspace\"\n      \"params\"\
+      :\n        \"overwrite\": false\n        \"source\": \"template\"\n        \"\
+      workspace\": \"default\"\n    - \"class\": \"trustgraph.bootstrap.initialisers.DefaultFlowStart\"\
+      \n      \"flag\": \"v1\"\n      \"name\": \"default-flow\"\n      \"params\"\
+      :\n        \"blueprint\": \"everything\"\n        \"description\": \"Default\"\
+      \n        \"flow_id\": \"default\"\n        \"workspace\": \"default\"\n   \
+      \ \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\""
   kind: ConfigMap
   metadata:
-    name: garage-cfg
-    namespace: trustgraph
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: garage-meta
-    namespace: trustgraph
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 2G
-    storageClassName: tg
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: garage-data
-    namespace: trustgraph
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 5G
-    storageClassName: tg
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: garage
-    name: garage
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: garage
-    template:
-      metadata:
-        labels:
-          app: garage
-      spec:
-        containers:
-        - command:
-          - /garage
-          - -c
-          - /etc/garage/garage.toml
-          - server
-          env:
-          - name: RUST_LOG
-            value: garage=info
-          image: docker.io/dxflrs/garage:v2.1.0
-          name: garage
-          ports:
-          - containerPort: 3900
-            hostPort: 3900
-          - containerPort: 3901
-            hostPort: 3901
-          - containerPort: 3902
-            hostPort: 3902
-          - containerPort: 3903
-            hostPort: 3903
-          - containerPort: 3904
-            hostPort: 3904
-          resources:
-            limits:
-              cpu: '1.0'
-              memory: 512M
-            requests:
-              cpu: '0.5'
-              memory: 512M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-          volumeMounts:
-          - mountPath: /etc/garage/
-            name: garage-cfg
-          - mountPath: /var/lib/garage/meta
-            name: garage-meta
-          - mountPath: /var/lib/garage/data
-            name: garage-data
-        volumes:
-        - configMap:
-            name: garage-cfg
-          name: garage-cfg
-        - name: garage-meta
-          persistentVolumeClaim:
-            claimName: garage-meta
-        - name: garage-data
-          persistentVolumeClaim:
-            claimName: garage-data
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: garage-init
-    name: garage-init
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: garage-init
-    template:
-      metadata:
-        labels:
-          app: garage-init
-      spec:
-        containers:
-        - command:
-          - sh
-          - -c
-          - "set -e\n\n# Install required tools\necho \"Installing curl, jq and downloading\
-            \ garage CLI...\"\napk add --no-cache curl jq\n\n# Download garage binary\
-            \ (v2.1.0) for remote management\ncurl -fsSL \"https://garagehq.deuxfleurs.fr/_releases/v2.1.0/x86_64-unknown-linux-musl/garage\"\
-            \ \\\n    -o /usr/local/bin/garage\nchmod +x /usr/local/bin/garage\n\n\
-            echo \"Waiting for Garage daemon to be ready...\"\nMAX_ATTEMPTS=60\nATTEMPT=0\n\
-            # Wait for /health to respond (even 503 is fine - means daemon is up)\n\
-            until curl -s http://garage:3903/health >/dev/null 2>&1; do\n    ATTEMPT=$((ATTEMPT+1))\n\
-            \    if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then\n        echo \"ERROR: Garage\
-            \ failed to become ready after ${MAX_ATTEMPTS} attempts\"\n        exit\
-            \ 1\n    fi\n    echo \"Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: Garage not\
-            \ ready, retrying in 2s...\"\n    sleep 2\ndone\necho \"Garage daemon\
-            \ is ready.\"\n\n# Get the node ID via v2 Admin API\necho \"Getting Garage\
-            \ node ID via Admin API...\"\ncurl -s -H \"Authorization: Bearer ${GARAGE_ADMIN_TOKEN}\"\
-            \ \\\n    \"http://garage:3903/v2/GetNodeInfo?node=self\" > /tmp/garage-node-info.json\n\
-            \n# Extract node ID from response (the key in success map is the node\
-            \ ID)\nNODE_ID=$(jq -r '.success | to_entries[0].value.nodeId' /tmp/garage-node-info.json)\n\
-            echo \"Node ID: ${NODE_ID}\"\n\nif [ -z \"$NODE_ID\" ] || [ \"$NODE_ID\"\
-            \ = \"null\" ]; then\n    echo \"ERROR: Failed to retrieve node ID\"\n\
-            \    exit 1\nfi\n\n# ===== LAYOUT MANAGEMENT VIA REMOTE RPC =====\n# Use\
-            \ garage CLI with -h and -s flags to connect remotely\n# -h requires format:\
-            \ <node-id>@<host>:<port>\n# -s provides the RPC secret\n\n# Construct\
-            \ full RPC identifier\nRPC_HOST=\"${NODE_ID}@garage:3901\"\necho \"RPC\
-            \ Host: ${RPC_HOST}\"\n\n# Check current layout to see if node is already\
-            \ assigned (idempotent)\necho \"Checking current cluster layout...\"\n\
-            LAYOUT_OUTPUT=$(garage -h \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\"\
-            \ layout show 2>&1)\n\n# Check if node already has a role assigned\n#\
-            \ Layout output shows abbreviated node ID (first 16 chars)\nNODE_ID_SHORT=\"\
-            ${NODE_ID:0:16}\"\nif echo \"$LAYOUT_OUTPUT\" | grep -q \"$NODE_ID_SHORT\"\
-            ; then\n    echo \"Node ${NODE_ID_SHORT}... already assigned in layout,\
-            \ skipping.\"\nelse\n    echo \"Assigning node to cluster layout...\"\n\
-            \    # Assign node to zone dc1 with configured capacity\n    garage -h\
-            \ \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\" \\\n        layout assign\
-            \ ${NODE_ID} -z dc1 -c ${GARAGE_DATA_SIZE}\n\n    echo \"Applying layout\
-            \ configuration...\"\n    # Get current staged version and apply\n   \
-            \ garage -h \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\" \\\n        layout\
-            \ apply --version 1\n\n    echo \"Layout configured successfully.\"\n\
-            \    # Wait for layout to stabilize\n    sleep 5\nfi\n\n# ===== KEY MANAGEMENT\
-            \ VIA REMOTE RPC =====\n\n# Check if key already exists (idempotent)\n\
-            # GARAGE_ACCESS_KEY is already a valid Garage Key ID (GK + 24 hex chars)\n\
-            if garage -h \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\" key info \"${GARAGE_ACCESS_KEY}\"\
-            \ >/dev/null 2>&1; then\n    echo \"Access key ${GARAGE_ACCESS_KEY} already\
-            \ exists, skipping creation.\"\nelse\n    echo \"Importing S3 access key:\
-            \ ${GARAGE_ACCESS_KEY}\"\n\n    # Import key with the provided credentials\
-            \ (both already in valid Garage format)\n    # GARAGE_ACCESS_KEY = Key\
-            \ ID (GK + 24 hex chars)\n    # GARAGE_SECRET_KEY = Secret (64 hex chars)\n\
-            \    garage -h \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\" \\\n      \
-            \  key import \"${GARAGE_ACCESS_KEY}\" \"${GARAGE_SECRET_KEY}\" --yes\n\
-            \n    echo \"Access key imported successfully.\"\nfi\n\n# Grant permissions\
-            \ to the key\necho \"Granting create-bucket permission to key...\"\ngarage\
-            \ -h \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\" \\\n    key allow --create-bucket\
-            \ \"${GARAGE_ACCESS_KEY}\"\n\necho \"\"\necho \"Garage initialization\
-            \ complete!\"\necho \"S3 Endpoint: http://garage:3900\"\necho \"Region:\
-            \ ${GARAGE_REGION}\"\nexit 0\n"
-          env:
-          - name: GARAGE_ACCESS_KEY
-            value: GK000000000000000000000001
-          - name: GARAGE_ADMIN_TOKEN
-            value: batts-rockhearted-unpartially
-          - name: GARAGE_DATA_SIZE
-            value: 5G
-          - name: GARAGE_REGION
-            value: garage
-          - name: GARAGE_RPC_SECRET
-            value: bbba746a9e289bad64a9e7a36a4299dac8d6e0b8cc2a6c2937fe756df4492008
-          - name: GARAGE_SECRET_KEY
-            value: b171f00be9be4c32c734f4c05fe64c527a8ab5eb823b376cfa8c2531f70fc427
-          image: docker.io/alpine:3.23.2
-          name: garage-init
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 256M
-            requests:
-              cpu: '0.25'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-          volumeMounts:
-          - mountPath: /etc/garage/
-            name: garage-cfg
-        volumes:
-        - configMap:
-            name: garage-cfg
-          name: garage-cfg
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: garage
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: s3-api
-      port: 3900
-      targetPort: 3900
-    - name: rpc
-      port: 3901
-      targetPort: 3901
-    - name: web
-      port: 3902
-      targetPort: 3902
-    - name: admin
-      port: 3903
-      targetPort: 3903
-    - name: k2v
-      port: 3904
-      targetPort: 3904
-    selector:
-      app: garage
-- apiVersion: v1
-  kind: PersistentVolumeClaim
-  metadata:
-    name: grafana-storage
-    namespace: trustgraph
-  spec:
-    accessModes:
-    - ReadWriteOnce
-    resources:
-      requests:
-        storage: 20G
-    storageClassName: tg
-- apiVersion: v1
-  data:
-    dashboard.yml: "\napiVersion: 1\n\nproviders:\n\n  - name: 'trustgraph.ai'\n \
-      \   orgId: 1\n    folder: 'TrustGraph'\n    folderUid: 'b6c5be90-d432-4df8-aeab-737c7b151228'\n\
-      \    type: file\n    disableDeletion: false\n    updateIntervalSeconds: 30\n\
-      \    allowUiUpdates: true\n    options:\n      path: /var/lib/grafana/dashboards\n\
-      \      foldersFromFilesStructure: false\n\n"
-  kind: ConfigMap
-  metadata:
-    name: prov-dash
+    name: control-launch-cfg
     namespace: trustgraph
 - apiVersion: v1
   data:
-    datasource.yml: "apiVersion: 1\n\nprune: true\n\ndatasources:\n  - name: Prometheus\n\
-      \    type: prometheus\n    access: proxy\n    orgId: 1\n    # <string> Sets\
-      \ a custom UID to reference this\n    # data source in other parts of the configuration.\n\
-      \    # If not specified, Grafana generates one.\n    uid: 'f6b18033-5918-4e05-a1ca-4cb30343b129'\n\
-      \n    url: http://prometheus:9090\n\n    basicAuth: false\n    withCredentials:\
-      \ false\n    isDefault: true\n    editable: true\n\n  - name: Loki\n    type:\
-      \ loki\n    access: proxy\n    orgId: 1\n    # <string> Sets a custom UID to\
-      \ reference this\n    # data source in other parts of the configuration.\n \
-      \   # If not specified, Grafana generates one.\n    uid: 'cf6m73l5rnvuod'\n\n\
-      \    url: http://loki:3100\n\n    basicAuth: false\n    withCredentials: false\n\
-      \    editable: true\n\n"
-  kind: ConfigMap
-  metadata:
-    name: prov-data
-    namespace: trustgraph
-- apiVersion: v1
-  data:
-    log-dashboard.json: "{\n  \"annotations\": {\n    \"list\": [\n      {\n     \
-      \   \"builtIn\": 1,\n        \"datasource\": {\n          \"type\": \"grafana\"\
-      ,\n          \"uid\": \"-- Grafana --\"\n        },\n        \"enable\": true,\n\
-      \        \"hide\": true,\n        \"iconColor\": \"rgba(0, 211, 255, 1)\",\n\
-      \        \"name\": \"Annotations & Alerts\",\n        \"type\": \"dashboard\"\
-      \n      }\n    ]\n  },\n  \"editable\": true,\n  \"fiscalYearStartMonth\": 0,\n\
-      \  \"graphTooltip\": 0,\n  \"id\": 3,\n  \"links\": [],\n  \"panels\": [\n \
-      \   {\n      \"datasource\": {\n        \"type\": \"loki\",\n        \"uid\"\
-      : \"cf6m73l5rnvuod\"\n      },\n      \"fieldConfig\": {\n        \"defaults\"\
-      : {\n          \"color\": {\n            \"mode\": \"palette-classic\"\n   \
-      \       },\n          \"custom\": {\n            \"axisBorderShow\": false,\n\
-      \            \"axisCenteredZero\": false,\n            \"axisColorMode\": \"\
-      text\",\n            \"axisLabel\": \"\",\n            \"axisPlacement\": \"\
-      auto\",\n            \"fillOpacity\": 33,\n            \"gradientMode\": \"\
-      none\",\n            \"hideFrom\": {\n              \"legend\": false,\n   \
-      \           \"tooltip\": false,\n              \"viz\": false\n            },\n\
-      \            \"lineWidth\": 1,\n            \"scaleDistribution\": {\n     \
-      \         \"type\": \"linear\"\n            },\n            \"thresholdsStyle\"\
-      : {\n              \"mode\": \"off\"\n            }\n          },\n        \
-      \  \"mappings\": [],\n          \"thresholds\": {\n            \"mode\": \"\
-      absolute\",\n            \"steps\": [\n              {\n                \"color\"\
-      : \"green\",\n                \"value\": 0\n              },\n             \
-      \ {\n                \"color\": \"red\",\n                \"value\": 80\n  \
-      \            }\n            ]\n          }\n        },\n        \"overrides\"\
-      : []\n      },\n      \"gridPos\": {\n        \"h\": 6,\n        \"w\": 24,\n\
-      \        \"x\": 0,\n        \"y\": 0\n      },\n      \"id\": 2,\n      \"options\"\
-      : {\n        \"barRadius\": 0,\n        \"barWidth\": 0.97,\n        \"fullHighlight\"\
-      : false,\n        \"groupWidth\": 0.7,\n        \"legend\": {\n          \"\
-      calcs\": [],\n          \"displayMode\": \"list\",\n          \"placement\"\
-      : \"bottom\",\n          \"showLegend\": true\n        },\n        \"orientation\"\
-      : \"auto\",\n        \"showValue\": \"never\",\n        \"stacking\": \"normal\"\
-      ,\n        \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\"\
-      : \"single\",\n          \"sort\": \"none\"\n        },\n        \"xTickLabelRotation\"\
-      : 0,\n        \"xTickLabelSpacing\": 100\n      },\n      \"pluginVersion\"\
-      : \"12.1.1\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
-      \            \"type\": \"loki\",\n            \"uid\": \"cf6m73l5rnvuod\"\n\
-      \          },\n          \"direction\": \"backward\",\n          \"editorMode\"\
-      : \"code\",\n          \"expr\": \"topk(5, sum by (processor) (count_over_time({severity=~\\\
-      \"error|critical\\\"} [$__auto])))\",\n          \"queryType\": \"range\",\n\
-      \          \"refId\": \"A\"\n        }\n      ],\n      \"title\": \"Error volume\"\
-      ,\n      \"type\": \"barchart\"\n    },\n    {\n      \"datasource\": {\n  \
-      \      \"type\": \"loki\",\n        \"uid\": \"cf6m73l5rnvuod\"\n      },\n\
-      \      \"fieldConfig\": {\n        \"defaults\": {},\n        \"overrides\"\
-      : []\n      },\n      \"gridPos\": {\n        \"h\": 18,\n        \"w\": 24,\n\
-      \        \"x\": 0,\n        \"y\": 6\n      },\n      \"id\": 1,\n      \"options\"\
-      : {\n        \"dedupStrategy\": \"none\",\n        \"enableInfiniteScrolling\"\
-      : false,\n        \"enableLogDetails\": true,\n        \"prettifyLogMessage\"\
-      : false,\n        \"showCommonLabels\": false,\n        \"showLabels\": false,\n\
-      \        \"showTime\": false,\n        \"sortOrder\": \"Descending\",\n    \
-      \    \"wrapLogMessage\": true\n      },\n      \"pluginVersion\": \"12.1.1\"\
-      ,\n      \"targets\": [\n        {\n          \"datasource\": {\n          \
-      \  \"type\": \"loki\",\n            \"uid\": \"cf6m73l5rnvuod\"\n          },\n\
-      \          \"direction\": \"backward\",\n          \"editorMode\": \"builder\"\
-      ,\n          \"expr\": \"{severity=~\\\"error|critical\\\"} |= ``\",\n     \
-      \     \"queryType\": \"range\",\n          \"refId\": \"A\"\n        }\n   \
-      \   ],\n      \"title\": \"Log errors\",\n      \"type\": \"logs\"\n    }\n\
-      \  ],\n  \"preload\": false,\n  \"schemaVersion\": 41,\n  \"tags\": [],\n  \"\
-      templating\": {\n    \"list\": []\n  },\n  \"time\": {\n    \"from\": \"now-15m\"\
-      ,\n    \"to\": \"now\"\n  },\n  \"timepicker\": {},\n  \"timezone\": \"browser\"\
-      ,\n  \"title\": \"Logs\",\n  \"uid\": \"4bdce405-0dd3-4a14-9a8f-792152ebebba\"\
-      ,\n  \"version\": 13\n}\n"
-    overview-dashboard.json: "{\n  \"annotations\": {\n    \"list\": [\n      {\n\
-      \        \"builtIn\": 1,\n        \"datasource\": {\n          \"type\": \"\
-      grafana\",\n          \"uid\": \"-- Grafana --\"\n        },\n        \"enable\"\
-      : true,\n        \"hide\": true,\n        \"iconColor\": \"rgba(0, 211, 255,\
-      \ 1)\",\n        \"name\": \"Annotations & Alerts\",\n        \"type\": \"dashboard\"\
-      \n      }\n    ]\n  },\n  \"editable\": true,\n  \"fiscalYearStartMonth\": 0,\n\
-      \  \"graphTooltip\": 0,\n  \"id\": 5,\n  \"links\": [],\n  \"panels\": [\n \
-      \   {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"\
-      uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\"\
-      : {\n        \"defaults\": {\n          \"color\": {\n            \"mode\":\
-      \ \"palette-classic\"\n          },\n          \"custom\": {\n            \"\
-      axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n       \
-      \     \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n     \
-      \       \"axisPlacement\": \"auto\",\n            \"barAlignment\": 0,\n   \
-      \         \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\",\n \
-      \           \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n \
-      \           \"hideFrom\": {\n              \"legend\": false,\n            \
-      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
-      \       \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
-      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
-      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
-      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
-      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
-      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
-      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
-      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
-      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
-      \       {\n                \"color\": \"green\",\n                \"value\"\
-      : 0\n              },\n              {\n                \"color\": \"red\",\n\
-      \                \"value\": 80\n              }\n            ]\n          }\n\
-      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
-      \     \"h\": 7,\n        \"w\": 12,\n        \"x\": 0,\n        \"y\": 0\n \
-      \     },\n      \"id\": 17,\n      \"options\": {\n        \"legend\": {\n \
-      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
-      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
-      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
-      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
-      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"editorMode\": \"\
-      code\",\n          \"expr\": \"producer_count_total{processor=\\\"chunker\\\"\
-      ,name=\\\"output\\\"}\\n- ignoring(instance, job, processor, name, status)\\\
-      nprocessing_count_total{processor=\\\"kg-extract-relationships\\\", name=\\\"\
-      input\\\"}\",\n          \"legendFormat\": \"__auto\",\n          \"range\"\
-      : true,\n          \"refId\": \"A\"\n        }\n      ],\n      \"title\": \"\
-      Knowledge extraction backlog\",\n      \"type\": \"timeseries\"\n    },\n  \
-      \  {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"\
-      uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\"\
-      : {\n        \"defaults\": {\n          \"color\": {\n            \"mode\":\
-      \ \"palette-classic\"\n          },\n          \"custom\": {\n            \"\
-      axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n       \
-      \     \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n     \
-      \       \"axisPlacement\": \"auto\",\n            \"barAlignment\": 0,\n   \
-      \         \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\",\n \
-      \           \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n \
-      \           \"hideFrom\": {\n              \"legend\": false,\n            \
-      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
-      \       \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
-      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
-      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
-      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
-      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
-      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
-      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
-      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
-      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
-      \       {\n                \"color\": \"green\",\n                \"value\"\
-      : 0\n              },\n              {\n                \"color\": \"red\",\n\
-      \                \"value\": 80\n              }\n            ]\n          }\n\
-      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
-      \     \"h\": 7,\n        \"w\": 6,\n        \"x\": 12,\n        \"y\": 0\n \
-      \     },\n      \"id\": 19,\n      \"options\": {\n        \"legend\": {\n \
-      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
-      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
-      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
-      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
-      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"editorMode\": \"\
-      code\",\n          \"expr\": \"(producer_count_total{processor=\\\"graph-embeddings\\\
-      \",name=\\\"output\\\"} - ignoring(instance, job, processor, name, status) processing_count_total{processor=\\\
-      \"ge-write\\\",name=\\\"input\\\"} >= 2)\\nor\\n(0 * (producer_count_total{processor=\\\
-      \"graph-embeddings\\\",name=\\\"output\\\"} - ignoring(instance, job, processor,\
-      \ name, status) processing_count_total{processor=\\\"ge-write\\\",name=\\\"\
-      input\\\"}))\",\n          \"legendFormat\": \"__auto\",\n          \"range\"\
-      : true,\n          \"refId\": \"A\"\n        }\n      ],\n      \"title\": \"\
-      Graph embeddings backlog\",\n      \"type\": \"timeseries\"\n    },\n    {\n\
-      \      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"uid\"\
-      : \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\"\
-      : {\n        \"defaults\": {\n          \"color\": {\n            \"mode\":\
-      \ \"palette-classic\"\n          },\n          \"custom\": {\n            \"\
-      axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n       \
-      \     \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n     \
-      \       \"axisPlacement\": \"auto\",\n            \"barAlignment\": 0,\n   \
-      \         \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\",\n \
-      \           \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n \
-      \           \"hideFrom\": {\n              \"legend\": false,\n            \
-      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
-      \       \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
-      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
-      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
-      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
-      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
-      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
-      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
-      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
-      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
-      \       {\n                \"color\": \"green\",\n                \"value\"\
-      : 0\n              },\n              {\n                \"color\": \"red\",\n\
-      \                \"value\": 80\n              }\n            ]\n          }\n\
-      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
-      \     \"h\": 7,\n        \"w\": 6,\n        \"x\": 18,\n        \"y\": 0\n \
-      \     },\n      \"id\": 18,\n      \"options\": {\n        \"legend\": {\n \
-      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
-      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
-      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
-      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
-      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"editorMode\": \"\
-      code\",\n          \"expr\": \"(clamp_min(\\n  (\\n    producer_count_total{processor=\\\
-      \"kg-extract-definitions\\\",name=\\\"triples\\\"}\\n    + on(flow)\\n    producer_count_total{processor=\\\
-      \"kg-extract-relationships\\\",name=\\\"triples\\\"}\\n  )\\n  - on(flow) processing_count_total{processor=\\\
-      \"triples-write\\\",name=\\\"input\\\"},\\n  0\\n) >= 2) or (0 * clamp_min(\\\
-      n  (\\n    producer_count_total{processor=\\\"kg-extract-definitions\\\",name=\\\
-      \"triples\\\"}\\n    + on(flow)\\n    producer_count_total{processor=\\\"kg-extract-relationships\\\
-      \",name=\\\"triples\\\"}\\n  )\\n  - on(flow) processing_count_total{processor=\\\
-      \"triples-write\\\",name=\\\"input\\\"},\\n  0\\n))\",\n          \"legendFormat\"\
-      : \"__auto\",\n          \"range\": true,\n          \"refId\": \"A\"\n    \
-      \    }\n      ],\n      \"title\": \"Triples backlog\",\n      \"type\": \"\
-      timeseries\"\n    },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\"\
-      ,\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n   \
-      \   \"fieldConfig\": {\n        \"defaults\": {\n          \"custom\": {\n \
-      \           \"hideFrom\": {\n              \"legend\": false,\n            \
-      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
-      \       \"scaleDistribution\": {\n              \"type\": \"linear\"\n     \
-      \       }\n          }\n        },\n        \"overrides\": []\n      },\n  \
-      \    \"gridPos\": {\n        \"h\": 8,\n        \"w\": 12,\n        \"x\": 0,\n\
-      \        \"y\": 7\n      },\n      \"id\": 7,\n      \"options\": {\n      \
-      \  \"calculate\": false,\n        \"cellGap\": 1,\n        \"color\": {\n  \
-      \        \"exponent\": 0.5,\n          \"fill\": \"dark-orange\",\n        \
-      \  \"mode\": \"scheme\",\n          \"reverse\": false,\n          \"scale\"\
-      : \"exponential\",\n          \"scheme\": \"Oranges\",\n          \"steps\"\
-      : 64\n        },\n        \"exemplars\": {\n          \"color\": \"rgba(255,0,255,0.7)\"\
-      \n        },\n        \"filterValues\": {\n          \"le\": 1e-9\n        },\n\
-      \        \"legend\": {\n          \"show\": true\n        },\n        \"rowsFrame\"\
-      : {\n          \"layout\": \"auto\"\n        },\n        \"tooltip\": {\n  \
-      \        \"mode\": \"single\",\n          \"showColorScale\": false,\n     \
-      \     \"yHistogram\": false\n        },\n        \"yAxis\": {\n          \"\
-      axisPlacement\": \"left\",\n          \"reverse\": false\n        }\n      },\n\
-      \      \"pluginVersion\": \"12.3.0\",\n      \"targets\": [\n        {\n   \
-      \       \"datasource\": {\n            \"type\": \"prometheus\",\n         \
-      \   \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n          },\n      \
-      \    \"disableTextWrap\": false,\n          \"editorMode\": \"builder\",\n \
-      \         \"exemplar\": false,\n          \"expr\": \"sum by(le) (rate(text_completion_duration_bucket[$__rate_interval]))\"\
-      ,\n          \"format\": \"heatmap\",\n          \"fullMetaSearch\": false,\n\
-      \          \"includeNullMetadata\": true,\n          \"instant\": false,\n \
-      \         \"legendFormat\": \"99%\",\n          \"range\": true,\n         \
-      \ \"refId\": \"A\",\n          \"useBackend\": false\n        }\n      ],\n\
-      \      \"title\": \"LLM latency\",\n      \"type\": \"heatmap\"\n    },\n  \
-      \  {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"\
-      uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\"\
-      : {\n        \"defaults\": {\n          \"custom\": {\n            \"hideFrom\"\
-      : {\n              \"legend\": false,\n              \"tooltip\": false,\n \
-      \             \"viz\": false\n            },\n            \"scaleDistribution\"\
-      : {\n              \"type\": \"linear\"\n            }\n          }\n      \
-      \  },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n        \"\
-      h\": 8,\n        \"w\": 12,\n        \"x\": 12,\n        \"y\": 7\n      },\n\
-      \      \"id\": 2,\n      \"options\": {\n        \"calculate\": false,\n   \
-      \     \"cellGap\": 5,\n        \"cellValues\": {\n          \"unit\": \"\"\n\
-      \        },\n        \"color\": {\n          \"exponent\": 0.5,\n          \"\
-      fill\": \"dark-orange\",\n          \"mode\": \"scheme\",\n          \"reverse\"\
-      : false,\n          \"scale\": \"exponential\",\n          \"scheme\": \"Oranges\"\
-      ,\n          \"steps\": 64\n        },\n        \"exemplars\": {\n         \
-      \ \"color\": \"rgba(255,0,255,0.7)\"\n        },\n        \"filterValues\":\
-      \ {\n          \"le\": 1e-9\n        },\n        \"legend\": {\n          \"\
-      show\": true\n        },\n        \"rowsFrame\": {\n          \"layout\": \"\
-      auto\"\n        },\n        \"tooltip\": {\n          \"mode\": \"single\",\n\
-      \          \"showColorScale\": false,\n          \"yHistogram\": false\n   \
-      \     },\n        \"yAxis\": {\n          \"axisLabel\": \"processing status\"\
-      ,\n          \"axisPlacement\": \"left\",\n          \"reverse\": false\n  \
-      \      }\n      },\n      \"pluginVersion\": \"12.3.0\",\n      \"targets\"\
-      : [\n        {\n          \"datasource\": {\n            \"type\": \"prometheus\"\
-      ,\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n         \
-      \ },\n          \"disableTextWrap\": false,\n          \"editorMode\": \"builder\"\
-      ,\n          \"exemplar\": false,\n          \"expr\": \"sum by(status) (rate(processing_count_total{status!=\\\
-      \"success\\\"}[$__rate_interval]))\",\n          \"format\": \"heatmap\",\n\
-      \          \"fullMetaSearch\": false,\n          \"includeNullMetadata\": true,\n\
-      \          \"instant\": false,\n          \"interval\": \"\",\n          \"\
-      legendFormat\": \"{{status}}\",\n          \"range\": true,\n          \"refId\"\
-      : \"A\",\n          \"useBackend\": false\n        }\n      ],\n      \"title\"\
-      : \"Error rate\",\n      \"type\": \"heatmap\"\n    },\n    {\n      \"datasource\"\
-      : {\n        \"type\": \"prometheus\",\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"\
-      color\": {\n            \"mode\": \"palette-classic\"\n          },\n      \
-      \    \"custom\": {\n            \"axisBorderShow\": false,\n            \"axisCenteredZero\"\
-      : false,\n            \"axisColorMode\": \"text\",\n            \"axisLabel\"\
-      : \"\",\n            \"axisPlacement\": \"auto\",\n            \"barAlignment\"\
-      : 0,\n            \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\"\
-      ,\n            \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n\
-      \            \"hideFrom\": {\n              \"legend\": false,\n           \
-      \   \"tooltip\": false,\n              \"viz\": false\n            },\n    \
-      \        \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
-      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
-      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
-      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
-      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
-      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
-      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
-      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
-      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
-      \       {\n                \"color\": \"green\",\n                \"value\"\
-      : 0\n              },\n              {\n                \"color\": \"red\",\n\
-      \                \"value\": 80\n              }\n            ]\n          }\n\
-      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
-      \     \"h\": 9,\n        \"w\": 12,\n        \"x\": 0,\n        \"y\": 15\n\
-      \      },\n      \"id\": 1,\n      \"options\": {\n        \"legend\": {\n \
-      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
-      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
-      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
-      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
-      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
-      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
-      : \"builder\",\n          \"expr\": \"sum by(processor) (rate(request_latency_count{processor!=\\\
-      \"config-svc\\\"}[$__rate_interval]))\",\n          \"fullMetaSearch\": false,\n\
-      \          \"includeNullMetadata\": true,\n          \"instant\": false,\n \
-      \         \"legendFormat\": \"{{job}}\",\n          \"range\": true,\n     \
-      \     \"refId\": \"A\",\n          \"useBackend\": false\n        }\n      ],\n\
-      \      \"title\": \"Request rate\",\n      \"type\": \"timeseries\"\n    },\n\
-      \    {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n       \
-      \ \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\"\
-      : {\n        \"defaults\": {\n          \"color\": {\n            \"mode\":\
-      \ \"palette-classic\"\n          },\n          \"custom\": {\n            \"\
-      axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n       \
-      \     \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n     \
-      \       \"axisPlacement\": \"auto\",\n            \"barAlignment\": 0,\n   \
-      \         \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\",\n \
-      \           \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n \
-      \           \"hideFrom\": {\n              \"legend\": false,\n            \
-      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
-      \       \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
-      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
-      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
-      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
-      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
-      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
-      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
-      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
-      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
-      \       {\n                \"color\": \"green\",\n                \"value\"\
-      : 0\n              },\n              {\n                \"color\": \"red\",\n\
-      \                \"value\": 80\n              }\n            ]\n          }\n\
-      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
-      \     \"h\": 9,\n        \"w\": 12,\n        \"x\": 12,\n        \"y\": 15\n\
-      \      },\n      \"id\": 5,\n      \"options\": {\n        \"legend\": {\n \
-      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
-      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
-      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
-      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
-      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
-      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
-      : \"builder\",\n          \"expr\": \"pulsar_msg_backlog{topic!=\\\"persistent://tg/config/config\\\
-      \"}\",\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\"\
-      : true,\n          \"instant\": false,\n          \"legendFormat\": \"{{topic}}\"\
-      ,\n          \"range\": true,\n          \"refId\": \"A\",\n          \"useBackend\"\
-      : false\n        }\n      ],\n      \"title\": \"Pub/sub backlog\",\n      \"\
-      type\": \"timeseries\"\n    },\n    {\n      \"datasource\": {\n        \"type\"\
-      : \"prometheus\",\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"\
-      color\": {\n            \"fixedColor\": \"semi-dark-green\",\n            \"\
-      mode\": \"palette-classic-by-name\"\n          },\n          \"custom\": {\n\
-      \            \"axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n\
-      \            \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n\
-      \            \"axisPlacement\": \"auto\",\n            \"fillOpacity\": 80,\n\
-      \            \"gradientMode\": \"none\",\n            \"hideFrom\": {\n    \
-      \          \"legend\": false,\n              \"tooltip\": false,\n         \
-      \     \"viz\": false\n            },\n            \"lineWidth\": 1,\n      \
-      \      \"scaleDistribution\": {\n              \"type\": \"linear\"\n      \
-      \      },\n            \"thresholdsStyle\": {\n              \"mode\": \"off\"\
-      \n            }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
-      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
-      \       {\n                \"color\": \"green\",\n                \"value\"\
-      : 0\n              },\n              {\n                \"color\": \"red\",\n\
-      \                \"value\": 80\n              }\n            ]\n          }\n\
-      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
-      \     \"h\": 7,\n        \"w\": 12,\n        \"x\": 0,\n        \"y\": 24\n\
-      \      },\n      \"id\": 10,\n      \"options\": {\n        \"barRadius\": 0,\n\
-      \        \"barWidth\": 0.97,\n        \"fullHighlight\": false,\n        \"\
-      groupWidth\": 0.7,\n        \"legend\": {\n          \"calcs\": [],\n      \
-      \    \"displayMode\": \"list\",\n          \"placement\": \"bottom\",\n    \
-      \      \"showLegend\": true\n        },\n        \"orientation\": \"auto\",\n\
-      \        \"showValue\": \"auto\",\n        \"stacking\": \"none\",\n       \
-      \ \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"single\"\
-      ,\n          \"sort\": \"none\"\n        },\n        \"xTickLabelRotation\"\
-      : 0,\n        \"xTickLabelSpacing\": 0\n      },\n      \"pluginVersion\": \"\
-      12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n  \
-      \          \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
-      : \"builder\",\n          \"exemplar\": false,\n          \"expr\": \"max by(le)\
-      \ (chunk_size_bucket)\",\n          \"format\": \"heatmap\",\n          \"fullMetaSearch\"\
-      : false,\n          \"includeNullMetadata\": false,\n          \"instant\":\
-      \ true,\n          \"legendFormat\": \"{{le}}\",\n          \"range\": false,\n\
-      \          \"refId\": \"A\",\n          \"useBackend\": false\n        }\n \
-      \     ],\n      \"title\": \"Chunk size\",\n      \"type\": \"barchart\"\n \
-      \   },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n\
-      \        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n     \
-      \ \"fieldConfig\": {\n        \"defaults\": {\n          \"color\": {\n    \
-      \        \"mode\": \"palette-classic\"\n          },\n          \"custom\":\
-      \ {\n            \"axisBorderShow\": false,\n            \"axisCenteredZero\"\
-      : false,\n            \"axisColorMode\": \"text\",\n            \"axisLabel\"\
-      : \"\",\n            \"axisPlacement\": \"auto\",\n            \"barAlignment\"\
-      : 0,\n            \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\"\
-      ,\n            \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n\
-      \            \"hideFrom\": {\n              \"legend\": false,\n           \
-      \   \"tooltip\": false,\n              \"viz\": false\n            },\n    \
-      \        \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
-      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
-      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
-      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
-      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
-      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
-      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
-      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
-      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
-      \       {\n                \"color\": \"green\",\n                \"value\"\
-      : 0\n              },\n              {\n                \"color\": \"red\",\n\
-      \                \"value\": 80\n              }\n            ]\n          }\n\
-      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
-      \     \"h\": 7,\n        \"w\": 12,\n        \"x\": 12,\n        \"y\": 24\n\
-      \      },\n      \"id\": 11,\n      \"options\": {\n        \"legend\": {\n\
-      \          \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
-      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
-      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
-      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
-      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
-      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
-      : \"builder\",\n          \"exemplar\": false,\n          \"expr\": \"sum by(job)\
-      \ (increase(rate_limit_count_total[$__rate_interval]))\",\n          \"format\"\
-      : \"time_series\",\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\"\
-      : true,\n          \"instant\": false,\n          \"legendFormat\": \"{{instance}}\"\
-      ,\n          \"range\": true,\n          \"refId\": \"A\",\n          \"useBackend\"\
-      : false\n        }\n      ],\n      \"title\": \"Rate limit events\",\n    \
-      \  \"type\": \"timeseries\"\n    },\n    {\n      \"datasource\": {\n      \
-      \  \"type\": \"prometheus\",\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"\
-      color\": {\n            \"fixedColor\": \"light-blue\",\n            \"mode\"\
-      : \"palette-classic\"\n          },\n          \"custom\": {\n            \"\
-      axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n       \
-      \     \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n     \
-      \       \"axisPlacement\": \"auto\",\n            \"barAlignment\": 0,\n   \
-      \         \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\",\n \
-      \           \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n \
-      \           \"hideFrom\": {\n              \"legend\": false,\n            \
-      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
-      \       \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
-      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
-      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
-      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
-      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
-      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
-      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
-      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
-      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
-      \       {\n                \"color\": \"green\",\n                \"value\"\
-      : 0\n              },\n              {\n                \"color\": \"red\",\n\
-      \                \"value\": 80\n              }\n            ]\n          }\n\
-      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
-      \     \"h\": 8,\n        \"w\": 12,\n        \"x\": 0,\n        \"y\": 31\n\
-      \      },\n      \"id\": 12,\n      \"options\": {\n        \"legend\": {\n\
-      \          \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
-      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
-      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
-      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
-      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
-      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
-      : \"builder\",\n          \"expr\": \"rate(process_cpu_seconds_total[$__rate_interval])\"\
-      ,\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\":\
-      \ true,\n          \"instant\": false,\n          \"legendFormat\": \"{{instance}}\"\
-      ,\n          \"range\": true,\n          \"refId\": \"A\",\n          \"useBackend\"\
-      : false\n        }\n      ],\n      \"title\": \"CPU\",\n      \"type\": \"\
-      timeseries\"\n    },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\"\
-      ,\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n   \
-      \   \"fieldConfig\": {\n        \"defaults\": {\n          \"color\": {\n  \
-      \          \"mode\": \"palette-classic\"\n          },\n          \"custom\"\
-      : {\n            \"axisBorderShow\": false,\n            \"axisCenteredZero\"\
-      : false,\n            \"axisColorMode\": \"text\",\n            \"axisLabel\"\
-      : \"GB\",\n            \"axisPlacement\": \"auto\",\n            \"barAlignment\"\
-      : 0,\n            \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\"\
-      ,\n            \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n\
-      \            \"hideFrom\": {\n              \"legend\": false,\n           \
-      \   \"tooltip\": false,\n              \"viz\": false\n            },\n    \
-      \        \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
-      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
-      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
-      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
-      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
-      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
-      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
-      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
-      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
-      \       {\n                \"color\": \"green\",\n                \"value\"\
-      : 0\n              },\n              {\n                \"color\": \"red\",\n\
-      \                \"value\": 80\n              }\n            ]\n          }\n\
-      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
-      \     \"h\": 8,\n        \"w\": 12,\n        \"x\": 12,\n        \"y\": 31\n\
-      \      },\n      \"id\": 13,\n      \"options\": {\n        \"legend\": {\n\
-      \          \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
-      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
-      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
-      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
-      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
-      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
-      : \"builder\",\n          \"expr\": \"process_resident_memory_bytes / 1073741824\"\
-      ,\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\":\
-      \ true,\n          \"instant\": false,\n          \"legendFormat\": \"{{instance}}\"\
-      ,\n          \"range\": true,\n          \"refId\": \"A\",\n          \"useBackend\"\
-      : false\n        }\n      ],\n      \"title\": \"Memory\",\n      \"type\":\
-      \ \"timeseries\"\n    },\n    {\n      \"datasource\": {\n        \"uid\": \"\
-      f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\": {\n\
-      \        \"defaults\": {\n          \"color\": {\n            \"mode\": \"thresholds\"\
-      \n          },\n          \"custom\": {\n            \"align\": \"auto\",\n\
-      \            \"cellOptions\": {\n              \"type\": \"auto\"\n        \
-      \    },\n            \"footer\": {\n              \"reducers\": []\n       \
-      \     },\n            \"hideFrom\": {\n              \"viz\": false\n      \
-      \      },\n            \"inspect\": false\n          },\n          \"mappings\"\
-      : [],\n          \"thresholds\": {\n            \"mode\": \"absolute\",\n  \
-      \          \"steps\": [\n              {\n                \"color\": \"green\"\
-      ,\n                \"value\": 0\n              },\n              {\n       \
-      \         \"color\": \"red\",\n                \"value\": 80\n             \
-      \ }\n            ]\n          }\n        },\n        \"overrides\": []\n   \
-      \   },\n      \"gridPos\": {\n        \"h\": 7,\n        \"w\": 8,\n       \
-      \ \"x\": 0,\n        \"y\": 39\n      },\n      \"id\": 14,\n      \"options\"\
-      : {\n        \"cellHeight\": \"sm\",\n        \"showHeader\": true\n      },\n\
-      \      \"pluginVersion\": \"12.3.0\",\n      \"targets\": [\n        {\n   \
-      \       \"editorMode\": \"code\",\n          \"exemplar\": false,\n        \
-      \  \"expr\": \"sum by (model) (tokens_total)\",\n          \"format\": \"table\"\
-      ,\n          \"instant\": true,\n          \"legendFormat\": \"__auto\",\n \
-      \         \"range\": false,\n          \"refId\": \"A\"\n        }\n      ],\n\
-      \      \"title\": \"Models in use\",\n      \"transformations\": [\n       \
-      \ {\n          \"id\": \"organize\",\n          \"options\": {\n           \
-      \ \"excludeByName\": {\n              \"Time\": true\n            },\n     \
-      \       \"includeByName\": {},\n            \"indexByName\": {},\n         \
-      \   \"renameByName\": {}\n          }\n        }\n      ],\n      \"type\":\
-      \ \"table\"\n    },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\"\
-      ,\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n   \
-      \   \"fieldConfig\": {\n        \"defaults\": {\n          \"color\": {\n  \
-      \          \"mode\": \"palette-classic\"\n          },\n          \"custom\"\
-      : {\n            \"axisBorderShow\": false,\n            \"axisCenteredZero\"\
-      : false,\n            \"axisColorMode\": \"text\",\n            \"axisLabel\"\
-      : \"\",\n            \"axisPlacement\": \"auto\",\n            \"barAlignment\"\
-      : 0,\n            \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\"\
-      ,\n            \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n\
-      \            \"hideFrom\": {\n              \"legend\": false,\n           \
-      \   \"tooltip\": false,\n              \"viz\": false\n            },\n    \
-      \        \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
-      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
-      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
-      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
-      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
-      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
-      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
-      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
-      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
-      \       {\n                \"color\": \"green\",\n                \"value\"\
-      : 0\n              },\n              {\n                \"color\": \"red\",\n\
-      \                \"value\": 80\n              }\n            ]\n          }\n\
-      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
-      \     \"h\": 7,\n        \"w\": 8,\n        \"x\": 8,\n        \"y\": 39\n \
-      \     },\n      \"id\": 15,\n      \"options\": {\n        \"legend\": {\n \
-      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
-      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
-      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
-      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
-      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
-      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
-      : \"builder\",\n          \"expr\": \"sum by(model, direction)  (rate(tokens_total[$__rate_interval]))\"\
-      ,\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\":\
-      \ true,\n          \"instant\": false,\n          \"legendFormat\": \"{{model}}\
-      \ - {{direction}}\",\n          \"range\": true,\n          \"refId\": \"A\"\
-      ,\n          \"useBackend\": false\n        }\n      ],\n      \"title\": \"\
-      Tokens\",\n      \"type\": \"timeseries\"\n    },\n    {\n      \"datasource\"\
-      : {\n        \"type\": \"prometheus\",\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"\
-      color\": {\n            \"mode\": \"palette-classic\"\n          },\n      \
-      \    \"custom\": {\n            \"axisBorderShow\": false,\n            \"axisCenteredZero\"\
-      : false,\n            \"axisColorMode\": \"text\",\n            \"axisLabel\"\
-      : \"$\",\n            \"axisPlacement\": \"auto\",\n            \"barAlignment\"\
-      : 0,\n            \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\"\
-      ,\n            \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n\
-      \            \"hideFrom\": {\n              \"legend\": false,\n           \
-      \   \"tooltip\": false,\n              \"viz\": false\n            },\n    \
-      \        \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
-      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
-      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
-      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
-      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
-      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
-      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
-      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
-      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
-      \       {\n                \"color\": \"green\",\n                \"value\"\
-      : 0\n              },\n              {\n                \"color\": \"red\",\n\
-      \                \"value\": 80\n              }\n            ]\n          }\n\
-      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
-      \     \"h\": 7,\n        \"w\": 8,\n        \"x\": 16,\n        \"y\": 39\n\
-      \      },\n      \"id\": 16,\n      \"options\": {\n        \"legend\": {\n\
-      \          \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
-      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
-      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
-      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
-      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
-      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
-      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
-      : \"builder\",\n          \"expr\": \"sum by(direction, model) (rate(tokens_total[$__rate_interval]))\"\
-      ,\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\":\
-      \ true,\n          \"instant\": false,\n          \"legendFormat\": \"{{model}}\
-      \ - {{direction}}\",\n          \"range\": true,\n          \"refId\": \"A\"\
-      ,\n          \"useBackend\": false\n        }\n      ],\n      \"title\": \"\
-      Token cost\",\n      \"type\": \"timeseries\"\n    }\n  ],\n  \"preload\": false,\n\
-      \  \"refresh\": \"5s\",\n  \"schemaVersion\": 42,\n  \"tags\": [],\n  \"templating\"\
-      : {\n    \"list\": []\n  },\n  \"time\": {\n    \"from\": \"now-1h\",\n    \"\
-      to\": \"now\"\n  },\n  \"timepicker\": {},\n  \"timezone\": \"\",\n  \"title\"\
-      : \"Overview (Pulsar)\",\n  \"uid\": \"ad77jv9\",\n  \"version\": 1\n}\n"
-  kind: ConfigMap
-  metadata:
-    name: dashboards
-    namespace: trustgraph
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: grafana
-    name: grafana
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: grafana
-    template:
-      metadata:
-        labels:
-          app: grafana
-      spec:
-        containers:
-        - env:
-          - name: GF_ORG_NAME
-            value: trustgraph.ai
-          image: docker.io/grafana/grafana:12.3.0
-          name: grafana
-          ports:
-          - containerPort: 3000
-            hostPort: 3000
-          resources:
-            limits:
-              cpu: '1.0'
-              memory: 256M
-            requests:
-              cpu: '0.5'
-              memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-          volumeMounts:
-          - mountPath: /var/lib/grafana
-            name: grafana-storage
-          - mountPath: /etc/grafana/provisioning/dashboards/
-            name: prov-dash
-          - mountPath: /etc/grafana/provisioning/datasources/
-            name: prov-data
-          - mountPath: /var/lib/grafana/dashboards/
-            name: dashboards
-        volumes:
-        - name: grafana-storage
-          persistentVolumeClaim:
-            claimName: grafana-storage
-        - configMap:
-            name: prov-dash
-          name: prov-dash
-        - configMap:
-            name: prov-data
-          name: prov-data
-        - configMap:
-            name: dashboards
-          name: dashboards
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: grafana
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: http
-      port: 3000
-      targetPort: 3000
-    selector:
-      app: grafana
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: graph-embeddings
-    name: graph-embeddings
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: graph-embeddings
-    template:
-      metadata:
-        labels:
-          app: graph-embeddings
-      spec:
-        containers:
-        - command:
-          - graph-embeddings
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: graph-embeddings
-          resources:
-            limits:
-              cpu: '1.0'
-              memory: 256M
-            requests:
-              cpu: '0.5'
-              memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: graph-embeddings
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: graph-embeddings
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: graph-rag
-    name: graph-rag
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: graph-rag
-    template:
-      metadata:
-        labels:
-          app: graph-rag
-      spec:
-        containers:
-        - command:
-          - graph-rag
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --concurrency
-          - '1'
-          - --entity-limit
-          - '50'
-          - --triple-limit
-          - '30'
-          - --edge-limit
-          - '30'
-          - --edge-score-limit
-          - '10'
-          - --max-subgraph-size
-          - '100'
-          - --max-path-length
-          - '2'
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: graph-rag
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: graph-rag
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: graph-rag
-- apiVersion: v1
-  data:
-    config.json: '{"active-flow": {"agent-manager": {"default": {"embeddings-request":
-      "request:tg:embeddings:default", "embeddings-response": "response:tg:embeddings:default",
-      "explainability": "flow:tg:triples-store:default", "graph-rag-request": "request:tg:graph-rag:default",
-      "graph-rag-response": "response:tg:graph-rag:default", "mcp-tool-request": "request:tg:mcp-tool:default",
-      "mcp-tool-response": "response:tg:mcp-tool:default", "next": "request:tg:agent:default",
-      "prompt-request": "request:tg:prompt-rag:default", "prompt-response": "response:tg:prompt-rag:default",
-      "request": "request:tg:agent:default", "response": "response:tg:agent:default",
-      "row-embeddings-query-request": "request:tg:row-embeddings:default", "row-embeddings-query-response":
-      "response:tg:row-embeddings:default", "structured-query-request": "request:tg:structured-query:default",
-      "structured-query-response": "response:tg:structured-query:default", "text-completion-request":
-      "request:tg:text-completion:default", "text-completion-response": "response:tg:text-completion:default"}},
-      "chunker": {"default": {"chunk-overlap": "50", "chunk-size": "2000", "input":
-      "flow:tg:text-document-load:default", "librarian-request": "request:tg:librarian",
-      "librarian-response": "request:tg:librarian", "output": "flow:tg:chunk-load:default",
-      "triples": "flow:tg:triples-store:default"}}, "doc-embeddings-query": {"default":
-      {"request": "request:tg:document-embeddings:default", "response": "response:tg:document-embeddings:default"}},
-      "doc-embeddings-write": {"default": {"input": "flow:tg:document-embeddings-store:default"}},
-      "document-decoder": {"default": {"input": "flow:tg:document-load:default", "librarian-request":
-      "request:tg:librarian", "librarian-response": "request:tg:librarian", "output":
-      "flow:tg:text-document-load:default", "triples": "flow:tg:triples-store:default"}},
-      "document-embeddings": {"default": {"embeddings-request": "request:tg:embeddings:default",
-      "embeddings-response": "response:tg:embeddings:default", "input": "flow:tg:chunk-load:default",
-      "output": "flow:tg:document-embeddings-store:default"}}, "document-rag": {"default":
-      {"document-embeddings-request": "request:tg:document-embeddings:default", "document-embeddings-response":
-      "response:tg:document-embeddings:default", "embeddings-request": "request:tg:embeddings:default",
-      "embeddings-response": "response:tg:embeddings:default", "explainability": "flow:tg:triples-store:default",
-      "prompt-request": "request:tg:prompt-rag:default", "prompt-response": "response:tg:prompt-rag:default",
-      "request": "request:tg:document-rag:default", "response": "response:tg:document-rag:default"}},
-      "embeddings": {"default": {"model": "sentence-transformers/all-MiniLM-L6-v2",
-      "request": "request:tg:embeddings:default", "response": "response:tg:embeddings:default"}},
-      "graph-embeddings": {"default": {"embeddings-request": "request:tg:embeddings:default",
-      "embeddings-response": "response:tg:embeddings:default", "input": "flow:tg:entity-contexts-load:default",
-      "output": "flow:tg:graph-embeddings-store:default"}}, "graph-embeddings-query":
-      {"default": {"request": "request:tg:graph-embeddings:default", "response": "response:tg:graph-embeddings:default"}},
-      "graph-embeddings-write": {"default": {"input": "flow:tg:graph-embeddings-store:default"}},
-      "graph-rag": {"default": {"embeddings-request": "request:tg:embeddings:default",
-      "embeddings-response": "response:tg:embeddings:default", "explainability": "flow:tg:triples-store:default",
-      "graph-embeddings-request": "request:tg:graph-embeddings:default", "graph-embeddings-response":
-      "response:tg:graph-embeddings:default", "librarian-request": "request:tg:librarian",
-      "librarian-response": "request:tg:librarian", "prompt-request": "request:tg:prompt-rag:default",
-      "prompt-response": "response:tg:prompt-rag:default", "request": "request:tg:graph-rag:default",
-      "response": "response:tg:graph-rag:default", "triples-request": "request:tg:triples:default",
-      "triples-response": "response:tg:triples:default"}}, "kg-extract-definitions":
-      {"default": {"entity-contexts": "flow:tg:entity-contexts-load:default", "input":
-      "flow:tg:chunk-load:default", "prompt-request": "request:tg:prompt:default",
-      "prompt-response": "response:tg:prompt:default", "triples": "flow:tg:triples-store:default"}},
-      "kg-extract-relationships": {"default": {"input": "flow:tg:chunk-load:default",
-      "prompt-request": "request:tg:prompt:default", "prompt-response": "response:tg:prompt:default",
-      "triples": "flow:tg:triples-store:default"}}, "kg-store": {"default": {"graph-embeddings-input":
-      "flow:tg:graph-embeddings-store:default", "triples-input": "flow:tg:triples-store:default"}},
-      "mcp-tool": {"default": {"request": "request:tg:mcp-tool:default", "response":
-      "response:tg:mcp-tool:default", "text-completion-request": "request:tg:text-completion:default",
-      "text-completion-response": "response:tg:text-completion:default"}}, "metering":
-      {"default": {"input": "response:tg:text-completion:default"}}, "metering-rag":
-      {"default": {"input": "response:tg:text-completion-rag:default"}}, "nlp-query":
-      {"default": {"prompt-request": "request:tg:prompt-rag:default", "prompt-response":
-      "response:tg:prompt-rag:default", "request": "request:tg:nlp-query:default",
-      "response": "response:tg:nlp-query:default"}}, "prompt": {"default": {"request":
-      "request:tg:prompt:default", "response": "response:tg:prompt:default", "text-completion-request":
-      "request:tg:text-completion:default", "text-completion-response": "response:tg:text-completion:default"}},
-      "prompt-rag": {"default": {"request": "request:tg:prompt-rag:default", "response":
-      "response:tg:prompt-rag:default", "text-completion-request": "request:tg:text-completion-rag:default",
-      "text-completion-response": "response:tg:text-completion-rag:default"}}, "row-embeddings":
-      {"default": {"embeddings-request": "request:tg:embeddings:default", "embeddings-response":
-      "response:tg:embeddings:default", "input": "flow:tg:rows-store:default", "output":
-      "flow:tg:row-embeddings-store:default"}}, "row-embeddings-query": {"default":
-      {"request": "request:tg:row-embeddings:default", "response": "response:tg:row-embeddings:default"}},
-      "row-embeddings-write": {"default": {"input": "flow:tg:row-embeddings-store:default"}},
-      "rows-query": {"default": {"request": "request:tg:rows:default", "response":
-      "response:tg:rows:default"}}, "rows-write": {"default": {"input": "flow:tg:rows-store:default"}},
-      "sparql-query": {"default": {"request": "request:tg:sparql:default", "response":
-      "response:tg:sparql:default", "triples-request": "request:tg:triples:default",
-      "triples-response": "response:tg:triples:default"}}, "structured-diag": {"default":
-      {"prompt-request": "request:tg:prompt:default", "prompt-response": "response:tg:prompt:default",
-      "request": "request:tg:structured-diag:default", "response": "response:tg:structured-diag:default"}},
-      "structured-query": {"default": {"nlp-query-request": "request:tg:nlp-query:default",
-      "nlp-query-response": "response:tg:nlp-query:default", "request": "request:tg:structured-query:default",
-      "response": "response:tg:structured-query:default", "rows-query-request": "request:tg:rows:default",
-      "rows-query-response": "response:tg:rows:default"}}, "text-completion": {"default":
-      {"model": "mistral-small-3.2-24b-instruct-2506", "request": "request:tg:text-completion:default",
-      "response": "response:tg:text-completion:default"}}, "text-completion-rag":
-      {"default": {"model": "mistral-small-3.2-24b-instruct-2506", "request": "request:tg:text-completion-rag:default",
-      "response": "response:tg:text-completion-rag:default"}}, "triples-query": {"default":
-      {"request": "request:tg:triples:default", "response": "response:tg:triples:default"}},
-      "triples-write": {"default": {"input": "flow:tg:triples-store:default"}}}, "agent-pattern":
-      {"plan-then-execute": {"description": "The agent first produces a structured
-      plan of steps, then executes each step in order. Supports re-planning on failure.",
-      "max_iterations": 15, "max_replan_depth": 2, "name": "plan-then-execute"}, "react":
-      {"description": "Interleaved reasoning and action \u2014 the agent thinks, selects
-      a tool, observes the result, and repeats until it has enough information to
-      answer.", "max_iterations": 10, "name": "react"}, "supervisor": {"description":
-      "The agent decomposes the question into independent sub-goals, fans out subagent
-      requests, waits for all to complete, then synthesises a final answer.", "max_subagents":
-      5, "name": "supervisor"}}, "agent-task-type": {"general": {"description": "No
-      domain framing. All patterns are valid.", "framing": "", "name": "general",
-      "valid_patterns": ["react", "plan-then-execute", "supervisor"]}, "research":
-      {"description": "Research-oriented queries requiring information gathering.",
-      "framing": "This is a research query. Focus on gathering accurate, well-sourced
-      information.", "name": "research", "valid_patterns": ["react", "plan-then-execute"]},
-      "risk-assessment": {"description": "Risk assessment queries requiring multi-dimensional
-      analysis.", "framing": "This is a risk assessment query. Consider multiple risk
-      dimensions and provide structured analysis.", "name": "risk-assessment", "valid_patterns":
-      ["supervisor", "plan-then-execute", "react"]}, "summarisation": {"description":
-      "Summarisation queries \u2014 straightforward information condensation.", "framing":
-      "This is a summarisation query. Focus on concise, accurate synthesis of the
-      available information.", "name": "summarisation", "valid_patterns": ["react"]}},
-      "collection": {"trustgraph:default": {"collection": "default", "description":
-      "Default collection", "name": "Default Collection", "tags": ["default"], "user":
-      "default-user"}}, "flow": {"default": {"blueprint-name": "everything", "description":
-      "Default processing flow", "interfaces": {"agent": {"request": "request:tg:agent:default",
-      "response": "response:tg:agent:default"}, "document-embeddings": {"request":
-      "request:tg:document-embeddings:default", "response": "response:tg:document-embeddings:default"},
-      "document-embeddings-store": "flow:tg:document-embeddings-store:default", "document-load":
-      "flow:tg:document-load:default", "document-rag": {"request": "request:tg:document-rag:default",
-      "response": "response:tg:document-rag:default"}, "embeddings": {"request": "request:tg:embeddings:default",
-      "response": "response:tg:embeddings:default"}, "entity-contexts-load": "flow:tg:entity-contexts-load:default",
-      "graph-embeddings": {"request": "request:tg:graph-embeddings:default", "response":
-      "response:tg:graph-embeddings:default"}, "graph-embeddings-store": "flow:tg:graph-embeddings-store:default",
-      "graph-rag": {"request": "request:tg:graph-rag:default", "response": "response:tg:graph-rag:default"},
-      "mcp-tool": {"request": "request:tg:mcp-tool:default", "response": "response:tg:mcp-tool:default"},
-      "nlp-query": {"request": "request:tg:nlp-query:default", "response": "response:tg:nlp-query:default"},
-      "prompt": {"request": "request:tg:prompt:default", "response": "response:tg:prompt:default"},
-      "row-embeddings": {"request": "request:tg:row-embeddings:default", "response":
-      "response:tg:row-embeddings:default"}, "row-embeddings-store": "flow:tg:row-embeddings-store:default",
-      "rows": {"request": "request:tg:rows:default", "response": "response:tg:rows:default"},
-      "rows-store": "flow:tg:rows-store:default", "sparql": {"request": "request:tg:sparql:default",
-      "response": "response:tg:sparql:default"}, "structured-diag": {"request": "request:tg:structured-diag:default",
-      "response": "response:tg:structured-diag:default"}, "structured-query": {"request":
-      "request:tg:structured-query:default", "response": "response:tg:structured-query:default"},
-      "text-completion": {"request": "request:tg:text-completion:default", "response":
-      "response:tg:text-completion:default"}, "text-load": "flow:tg:text-document-load:default",
-      "triples": {"request": "request:tg:triples:default", "response": "response:tg:triples:default"},
-      "triples-store": "flow:tg:triples-store:default"}, "parameters": {"chunk-overlap":
-      "50", "chunk-size": "2000", "embeddings-model": "sentence-transformers/all-MiniLM-L6-v2",
-      "llm-model": "mistral-small-3.2-24b-instruct-2506", "llm-rag-model": "mistral-small-3.2-24b-instruct-2506",
-      "llm-rag-temperature": "0.300", "llm-temperature": "0.300"}}}, "flow-blueprint":
-      {"everything": {"blueprint": {}, "description": "Graph RAG + Document RAG +
-      knowledge cores", "flow": {"agent-manager:{id}": {"embeddings-request": "request:tg:embeddings:{id}",
-      "embeddings-response": "response:tg:embeddings:{id}", "explainability": "flow:tg:triples-store:{id}",
-      "graph-rag-request": "request:tg:graph-rag:{id}", "graph-rag-response": "response:tg:graph-rag:{id}",
-      "mcp-tool-request": "request:tg:mcp-tool:{id}", "mcp-tool-response": "response:tg:mcp-tool:{id}",
-      "next": "request:tg:agent:{id}", "prompt-request": "request:tg:prompt-rag:{id}",
-      "prompt-response": "response:tg:prompt-rag:{id}", "request": "request:tg:agent:{id}",
-      "response": "response:tg:agent:{id}", "row-embeddings-query-request": "request:tg:row-embeddings:{id}",
-      "row-embeddings-query-response": "response:tg:row-embeddings:{id}", "structured-query-request":
-      "request:tg:structured-query:{id}", "structured-query-response": "response:tg:structured-query:{id}",
-      "text-completion-request": "request:tg:text-completion:{id}", "text-completion-response":
-      "response:tg:text-completion:{id}"}, "chunker:{id}": {"chunk-overlap": "{chunk-overlap}",
-      "chunk-size": "{chunk-size}", "input": "flow:tg:text-document-load:{id}", "librarian-request":
-      "request:tg:librarian", "librarian-response": "request:tg:librarian", "output":
-      "flow:tg:chunk-load:{id}", "triples": "flow:tg:triples-store:{id}"}, "doc-embeddings-query:{id}":
-      {"request": "request:tg:document-embeddings:{id}", "response": "response:tg:document-embeddings:{id}"},
-      "doc-embeddings-write:{id}": {"input": "flow:tg:document-embeddings-store:{id}"},
-      "document-decoder:{id}": {"input": "flow:tg:document-load:{id}", "librarian-request":
-      "request:tg:librarian", "librarian-response": "request:tg:librarian", "output":
-      "flow:tg:text-document-load:{id}", "triples": "flow:tg:triples-store:{id}"},
-      "document-embeddings:{id}": {"embeddings-request": "request:tg:embeddings:{id}",
-      "embeddings-response": "response:tg:embeddings:{id}", "input": "flow:tg:chunk-load:{id}",
-      "output": "flow:tg:document-embeddings-store:{id}"}, "document-rag:{id}": {"document-embeddings-request":
-      "request:tg:document-embeddings:{id}", "document-embeddings-response": "response:tg:document-embeddings:{id}",
-      "embeddings-request": "request:tg:embeddings:{id}", "embeddings-response": "response:tg:embeddings:{id}",
-      "explainability": "flow:tg:triples-store:{id}", "prompt-request": "request:tg:prompt-rag:{id}",
-      "prompt-response": "response:tg:prompt-rag:{id}", "request": "request:tg:document-rag:{id}",
-      "response": "response:tg:document-rag:{id}"}, "embeddings:{id}": {"model": "{embeddings-model}",
-      "request": "request:tg:embeddings:{id}", "response": "response:tg:embeddings:{id}"},
-      "graph-embeddings-query:{id}": {"request": "request:tg:graph-embeddings:{id}",
-      "response": "response:tg:graph-embeddings:{id}"}, "graph-embeddings-write:{id}":
-      {"input": "flow:tg:graph-embeddings-store:{id}"}, "graph-embeddings:{id}": {"embeddings-request":
-      "request:tg:embeddings:{id}", "embeddings-response": "response:tg:embeddings:{id}",
-      "input": "flow:tg:entity-contexts-load:{id}", "output": "flow:tg:graph-embeddings-store:{id}"},
-      "graph-rag:{id}": {"embeddings-request": "request:tg:embeddings:{id}", "embeddings-response":
-      "response:tg:embeddings:{id}", "explainability": "flow:tg:triples-store:{id}",
-      "graph-embeddings-request": "request:tg:graph-embeddings:{id}", "graph-embeddings-response":
-      "response:tg:graph-embeddings:{id}", "librarian-request": "request:tg:librarian",
-      "librarian-response": "request:tg:librarian", "prompt-request": "request:tg:prompt-rag:{id}",
-      "prompt-response": "response:tg:prompt-rag:{id}", "request": "request:tg:graph-rag:{id}",
-      "response": "response:tg:graph-rag:{id}", "triples-request": "request:tg:triples:{id}",
-      "triples-response": "response:tg:triples:{id}"}, "kg-extract-definitions:{id}":
-      {"entity-contexts": "flow:tg:entity-contexts-load:{id}", "input": "flow:tg:chunk-load:{id}",
-      "prompt-request": "request:tg:prompt:{id}", "prompt-response": "response:tg:prompt:{id}",
-      "triples": "flow:tg:triples-store:{id}"}, "kg-extract-relationships:{id}": {"input":
-      "flow:tg:chunk-load:{id}", "prompt-request": "request:tg:prompt:{id}", "prompt-response":
-      "response:tg:prompt:{id}", "triples": "flow:tg:triples-store:{id}"}, "kg-store:{id}":
-      {"graph-embeddings-input": "flow:tg:graph-embeddings-store:{id}", "triples-input":
-      "flow:tg:triples-store:{id}"}, "mcp-tool:{id}": {"request": "request:tg:mcp-tool:{id}",
-      "response": "response:tg:mcp-tool:{id}", "text-completion-request": "request:tg:text-completion:{id}",
-      "text-completion-response": "response:tg:text-completion:{id}"}, "metering-rag:{id}":
-      {"input": "response:tg:text-completion-rag:{id}"}, "metering:{id}": {"input":
-      "response:tg:text-completion:{id}"}, "nlp-query:{id}": {"prompt-request": "request:tg:prompt-rag:{id}",
-      "prompt-response": "response:tg:prompt-rag:{id}", "request": "request:tg:nlp-query:{id}",
-      "response": "response:tg:nlp-query:{id}"}, "prompt-rag:{id}": {"request": "request:tg:prompt-rag:{id}",
-      "response": "response:tg:prompt-rag:{id}", "text-completion-request": "request:tg:text-completion-rag:{id}",
-      "text-completion-response": "response:tg:text-completion-rag:{id}"}, "prompt:{id}":
-      {"request": "request:tg:prompt:{id}", "response": "response:tg:prompt:{id}",
-      "text-completion-request": "request:tg:text-completion:{id}", "text-completion-response":
-      "response:tg:text-completion:{id}"}, "row-embeddings-query:{id}": {"request":
-      "request:tg:row-embeddings:{id}", "response": "response:tg:row-embeddings:{id}"},
-      "row-embeddings-write:{id}": {"input": "flow:tg:row-embeddings-store:{id}"},
-      "row-embeddings:{id}": {"embeddings-request": "request:tg:embeddings:{id}",
-      "embeddings-response": "response:tg:embeddings:{id}", "input": "flow:tg:rows-store:{id}",
-      "output": "flow:tg:row-embeddings-store:{id}"}, "rows-query:{id}": {"request":
-      "request:tg:rows:{id}", "response": "response:tg:rows:{id}"}, "rows-write:{id}":
-      {"input": "flow:tg:rows-store:{id}"}, "sparql-query:{id}": {"request": "request:tg:sparql:{id}",
-      "response": "response:tg:sparql:{id}", "triples-request": "request:tg:triples:{id}",
-      "triples-response": "response:tg:triples:{id}"}, "structured-diag:{id}": {"prompt-request":
-      "request:tg:prompt:{id}", "prompt-response": "response:tg:prompt:{id}", "request":
-      "request:tg:structured-diag:{id}", "response": "response:tg:structured-diag:{id}"},
-      "structured-query:{id}": {"nlp-query-request": "request:tg:nlp-query:{id}",
-      "nlp-query-response": "response:tg:nlp-query:{id}", "request": "request:tg:structured-query:{id}",
-      "response": "response:tg:structured-query:{id}", "rows-query-request": "request:tg:rows:{id}",
-      "rows-query-response": "response:tg:rows:{id}"}, "text-completion-rag:{id}":
-      {"model": "{llm-rag-model}", "request": "request:tg:text-completion-rag:{id}",
-      "response": "response:tg:text-completion-rag:{id}"}, "text-completion:{id}":
-      {"model": "{llm-model}", "request": "request:tg:text-completion:{id}", "response":
-      "response:tg:text-completion:{id}"}, "triples-query:{id}": {"request": "request:tg:triples:{id}",
-      "response": "response:tg:triples:{id}"}, "triples-write:{id}": {"input": "flow:tg:triples-store:{id}"}},
-      "interfaces": {"agent": {"request": "request:tg:agent:{id}", "response": "response:tg:agent:{id}"},
-      "document-embeddings": {"request": "request:tg:document-embeddings:{id}", "response":
-      "response:tg:document-embeddings:{id}"}, "document-embeddings-store": "flow:tg:document-embeddings-store:{id}",
-      "document-load": "flow:tg:document-load:{id}", "document-rag": {"request": "request:tg:document-rag:{id}",
-      "response": "response:tg:document-rag:{id}"}, "embeddings": {"request": "request:tg:embeddings:{id}",
-      "response": "response:tg:embeddings:{id}"}, "entity-contexts-load": "flow:tg:entity-contexts-load:{id}",
-      "graph-embeddings": {"request": "request:tg:graph-embeddings:{id}", "response":
-      "response:tg:graph-embeddings:{id}"}, "graph-embeddings-store": "flow:tg:graph-embeddings-store:{id}",
-      "graph-rag": {"request": "request:tg:graph-rag:{id}", "response": "response:tg:graph-rag:{id}"},
-      "mcp-tool": {"request": "request:tg:mcp-tool:{id}", "response": "response:tg:mcp-tool:{id}"},
-      "nlp-query": {"request": "request:tg:nlp-query:{id}", "response": "response:tg:nlp-query:{id}"},
-      "prompt": {"request": "request:tg:prompt:{id}", "response": "response:tg:prompt:{id}"},
-      "row-embeddings": {"request": "request:tg:row-embeddings:{id}", "response":
-      "response:tg:row-embeddings:{id}"}, "row-embeddings-store": "flow:tg:row-embeddings-store:{id}",
-      "rows": {"request": "request:tg:rows:{id}", "response": "response:tg:rows:{id}"},
-      "rows-store": "flow:tg:rows-store:{id}", "sparql": {"request": "request:tg:sparql:{id}",
-      "response": "response:tg:sparql:{id}"}, "structured-diag": {"request": "request:tg:structured-diag:{id}",
-      "response": "response:tg:structured-diag:{id}"}, "structured-query": {"request":
-      "request:tg:structured-query:{id}", "response": "response:tg:structured-query:{id}"},
-      "text-completion": {"request": "request:tg:text-completion:{id}", "response":
-      "response:tg:text-completion:{id}"}, "text-load": "flow:tg:text-document-load:{id}",
-      "triples": {"request": "request:tg:triples:{id}", "response": "response:tg:triples:{id}"},
-      "triples-store": "flow:tg:triples-store:{id}"}, "parameters": {"chunk-overlap":
+    config.json: '{"agent-pattern": {"plan-then-execute": {"description": "The agent
+      first produces a structured plan of steps, then executes each step in order.
+      Supports re-planning on failure.", "max_iterations": 15, "max_replan_depth":
+      2, "name": "plan-then-execute"}, "react": {"description": "Interleaved reasoning
+      and action \u2014 the agent thinks, selects a tool, observes the result, and
+      repeats until it has enough information to answer.", "max_iterations": 10, "name":
+      "react"}, "supervisor": {"description": "The agent decomposes the question into
+      independent sub-goals, fans out subagent requests, waits for all to complete,
+      then synthesises a final answer.", "max_subagents": 5, "name": "supervisor"}},
+      "agent-task-type": {"general": {"description": "No domain framing. All patterns
+      are valid.", "framing": "", "name": "general", "valid_patterns": ["react", "plan-then-execute",
+      "supervisor"]}, "research": {"description": "Research-oriented queries requiring
+      information gathering.", "framing": "This is a research query. Focus on gathering
+      accurate, well-sourced information.", "name": "research", "valid_patterns":
+      ["react", "plan-then-execute"]}, "risk-assessment": {"description": "Risk assessment
+      queries requiring multi-dimensional analysis.", "framing": "This is a risk assessment
+      query. Consider multiple risk dimensions and provide structured analysis.",
+      "name": "risk-assessment", "valid_patterns": ["supervisor", "plan-then-execute",
+      "react"]}, "summarisation": {"description": "Summarisation queries \u2014 straightforward
+      information condensation.", "framing": "This is a summarisation query. Focus
+      on concise, accurate synthesis of the available information.", "name": "summarisation",
+      "valid_patterns": ["react"]}}, "collection": {"default": {"collection": "default",
+      "description": "Default collection", "name": "Default Collection", "tags": ["default"],
+      "user": "default-user"}}, "flow-blueprint": {"everything": {"blueprint": {},
+      "description": "Graph RAG + Document RAG + knowledge cores", "flow": {"agent-manager:{id}":
+      {"topics": {"embeddings-request": "request:tg:embeddings:{workspace}:{id}",
+      "embeddings-response": "response:tg:embeddings:{workspace}:{id}", "explainability":
+      "flow:tg:triples-store:{workspace}:{id}", "graph-rag-request": "request:tg:graph-rag:{workspace}:{id}",
+      "graph-rag-response": "response:tg:graph-rag:{workspace}:{id}", "librarian-request":
+      "request:tg:librarian:{workspace}", "librarian-response": "response:tg:librarian:{workspace}",
+      "mcp-tool-request": "request:tg:mcp-tool:{workspace}:{id}", "mcp-tool-response":
+      "response:tg:mcp-tool:{workspace}:{id}", "next": "request:tg:agent:{workspace}:{id}",
+      "prompt-request": "request:tg:prompt-rag:{workspace}:{id}", "prompt-response":
+      "response:tg:prompt-rag:{workspace}:{id}", "request": "request:tg:agent:{workspace}:{id}",
+      "response": "response:tg:agent:{workspace}:{id}", "row-embeddings-query-request":
+      "request:tg:row-embeddings:{workspace}:{id}", "row-embeddings-query-response":
+      "response:tg:row-embeddings:{workspace}:{id}", "structured-query-request": "request:tg:structured-query:{workspace}:{id}",
+      "structured-query-response": "response:tg:structured-query:{workspace}:{id}",
+      "text-completion-request": "request:tg:text-completion:{workspace}:{id}", "text-completion-response":
+      "response:tg:text-completion:{workspace}:{id}"}}, "chunker:{id}": {"parameters":
+      {"chunk-overlap": "{chunk-overlap}", "chunk-size": "{chunk-size}"}, "topics":
+      {"input": "flow:tg:text-document-load:{workspace}:{id}", "librarian-request":
+      "request:tg:librarian:{workspace}", "librarian-response": "response:tg:librarian:{workspace}",
+      "output": "flow:tg:chunk-load:{workspace}:{id}", "triples": "flow:tg:triples-store:{workspace}:{id}"}},
+      "doc-embeddings-query:{id}": {"topics": {"request": "request:tg:document-embeddings:{workspace}:{id}",
+      "response": "response:tg:document-embeddings:{workspace}:{id}"}}, "doc-embeddings-write:{id}":
+      {"topics": {"input": "flow:tg:document-embeddings-store:{workspace}:{id}"}},
+      "document-decoder:{id}": {"topics": {"input": "flow:tg:document-load:{workspace}:{id}",
+      "librarian-request": "request:tg:librarian:{workspace}", "librarian-response":
+      "response:tg:librarian:{workspace}", "output": "flow:tg:text-document-load:{workspace}:{id}",
+      "triples": "flow:tg:triples-store:{workspace}:{id}"}}, "document-embeddings:{id}":
+      {"topics": {"embeddings-request": "request:tg:embeddings:{workspace}:{id}",
+      "embeddings-response": "response:tg:embeddings:{workspace}:{id}", "input": "flow:tg:chunk-load:{workspace}:{id}",
+      "output": "flow:tg:document-embeddings-store:{workspace}:{id}"}}, "document-rag:{id}":
+      {"topics": {"document-embeddings-request": "request:tg:document-embeddings:{workspace}:{id}",
+      "document-embeddings-response": "response:tg:document-embeddings:{workspace}:{id}",
+      "embeddings-request": "request:tg:embeddings:{workspace}:{id}", "embeddings-response":
+      "response:tg:embeddings:{workspace}:{id}", "explainability": "flow:tg:triples-store:{workspace}:{id}",
+      "librarian-request": "request:tg:librarian:{workspace}", "librarian-response":
+      "response:tg:librarian:{workspace}", "prompt-request": "request:tg:prompt-rag:{workspace}:{id}",
+      "prompt-response": "response:tg:prompt-rag:{workspace}:{id}", "request": "request:tg:document-rag:{workspace}:{id}",
+      "response": "response:tg:document-rag:{workspace}:{id}"}}, "embeddings:{id}":
+      {"parameters": {"model": "{embeddings-model}"}, "topics": {"request": "request:tg:embeddings:{workspace}:{id}",
+      "response": "response:tg:embeddings:{workspace}:{id}"}}, "graph-embeddings-query:{id}":
+      {"topics": {"request": "request:tg:graph-embeddings:{workspace}:{id}", "response":
+      "response:tg:graph-embeddings:{workspace}:{id}"}}, "graph-embeddings-write:{id}":
+      {"topics": {"input": "flow:tg:graph-embeddings-store:{workspace}:{id}"}}, "graph-embeddings:{id}":
+      {"topics": {"embeddings-request": "request:tg:embeddings:{workspace}:{id}",
+      "embeddings-response": "response:tg:embeddings:{workspace}:{id}", "input": "flow:tg:entity-contexts-load:{workspace}:{id}",
+      "output": "flow:tg:graph-embeddings-store:{workspace}:{id}"}}, "graph-rag:{id}":
+      {"topics": {"embeddings-request": "request:tg:embeddings:{workspace}:{id}",
+      "embeddings-response": "response:tg:embeddings:{workspace}:{id}", "explainability":
+      "flow:tg:triples-store:{workspace}:{id}", "graph-embeddings-request": "request:tg:graph-embeddings:{workspace}:{id}",
+      "graph-embeddings-response": "response:tg:graph-embeddings:{workspace}:{id}",
+      "librarian-request": "request:tg:librarian:{workspace}", "librarian-response":
+      "response:tg:librarian:{workspace}", "prompt-request": "request:tg:prompt-rag:{workspace}:{id}",
+      "prompt-response": "response:tg:prompt-rag:{workspace}:{id}", "request": "request:tg:graph-rag:{workspace}:{id}",
+      "response": "response:tg:graph-rag:{workspace}:{id}", "triples-request": "request:tg:triples:{workspace}:{id}",
+      "triples-response": "response:tg:triples:{workspace}:{id}"}}, "kg-extract-definitions:{id}":
+      {"topics": {"entity-contexts": "flow:tg:entity-contexts-load:{workspace}:{id}",
+      "input": "flow:tg:chunk-load:{workspace}:{id}", "prompt-request": "request:tg:prompt:{workspace}:{id}",
+      "prompt-response": "response:tg:prompt:{workspace}:{id}", "triples": "flow:tg:triples-store:{workspace}:{id}"}},
+      "kg-extract-relationships:{id}": {"topics": {"input": "flow:tg:chunk-load:{workspace}:{id}",
+      "prompt-request": "request:tg:prompt:{workspace}:{id}", "prompt-response": "response:tg:prompt:{workspace}:{id}",
+      "triples": "flow:tg:triples-store:{workspace}:{id}"}}, "kg-store:{id}": {"topics":
+      {"graph-embeddings-input": "flow:tg:graph-embeddings-store:{workspace}:{id}",
+      "triples-input": "flow:tg:triples-store:{workspace}:{id}"}}, "mcp-tool:{id}":
+      {"topics": {"request": "request:tg:mcp-tool:{workspace}:{id}", "response": "response:tg:mcp-tool:{workspace}:{id}",
+      "text-completion-request": "request:tg:text-completion:{workspace}:{id}", "text-completion-response":
+      "response:tg:text-completion:{workspace}:{id}"}}, "metering-rag:{id}": {"topics":
+      {"input": "response:tg:text-completion-rag:{workspace}:{id}"}}, "metering:{id}":
+      {"topics": {"input": "response:tg:text-completion:{workspace}:{id}"}}, "nlp-query:{id}":
+      {"topics": {"prompt-request": "request:tg:prompt-rag:{workspace}:{id}", "prompt-response":
+      "response:tg:prompt-rag:{workspace}:{id}", "request": "request:tg:nlp-query:{workspace}:{id}",
+      "response": "response:tg:nlp-query:{workspace}:{id}"}}, "prompt-rag:{id}": {"topics":
+      {"request": "request:tg:prompt-rag:{workspace}:{id}", "response": "response:tg:prompt-rag:{workspace}:{id}",
+      "text-completion-request": "request:tg:text-completion-rag:{workspace}:{id}",
+      "text-completion-response": "response:tg:text-completion-rag:{workspace}:{id}"}},
+      "prompt:{id}": {"topics": {"request": "request:tg:prompt:{workspace}:{id}",
+      "response": "response:tg:prompt:{workspace}:{id}", "text-completion-request":
+      "request:tg:text-completion:{workspace}:{id}", "text-completion-response": "response:tg:text-completion:{workspace}:{id}"}},
+      "row-embeddings-query:{id}": {"topics": {"request": "request:tg:row-embeddings:{workspace}:{id}",
+      "response": "response:tg:row-embeddings:{workspace}:{id}"}}, "row-embeddings-write:{id}":
+      {"topics": {"input": "flow:tg:row-embeddings-store:{workspace}:{id}"}}, "row-embeddings:{id}":
+      {"topics": {"embeddings-request": "request:tg:embeddings:{workspace}:{id}",
+      "embeddings-response": "response:tg:embeddings:{workspace}:{id}", "input": "flow:tg:rows-store:{workspace}:{id}",
+      "output": "flow:tg:row-embeddings-store:{workspace}:{id}"}}, "rows-query:{id}":
+      {"topics": {"request": "request:tg:rows:{workspace}:{id}", "response": "response:tg:rows:{workspace}:{id}"}},
+      "rows-write:{id}": {"topics": {"input": "flow:tg:rows-store:{workspace}:{id}"}},
+      "sparql-query:{id}": {"topics": {"request": "request:tg:sparql:{workspace}:{id}",
+      "response": "response:tg:sparql:{workspace}:{id}", "triples-request": "request:tg:triples:{workspace}:{id}",
+      "triples-response": "response:tg:triples:{workspace}:{id}"}}, "structured-diag:{id}":
+      {"topics": {"prompt-request": "request:tg:prompt:{workspace}:{id}", "prompt-response":
+      "response:tg:prompt:{workspace}:{id}", "request": "request:tg:structured-diag:{workspace}:{id}",
+      "response": "response:tg:structured-diag:{workspace}:{id}"}}, "structured-query:{id}":
+      {"topics": {"nlp-query-request": "request:tg:nlp-query:{workspace}:{id}", "nlp-query-response":
+      "response:tg:nlp-query:{workspace}:{id}", "request": "request:tg:structured-query:{workspace}:{id}",
+      "response": "response:tg:structured-query:{workspace}:{id}", "rows-query-request":
+      "request:tg:rows:{workspace}:{id}", "rows-query-response": "response:tg:rows:{workspace}:{id}"}},
+      "text-completion-rag:{id}": {"parameters": {"model": "{llm-rag-model}"}, "topics":
+      {"request": "request:tg:text-completion-rag:{workspace}:{id}", "response": "response:tg:text-completion-rag:{workspace}:{id}"}},
+      "text-completion:{id}": {"parameters": {"model": "{llm-model}"}, "topics": {"request":
+      "request:tg:text-completion:{workspace}:{id}", "response": "response:tg:text-completion:{workspace}:{id}"}},
+      "triples-query:{id}": {"topics": {"request": "request:tg:triples:{workspace}:{id}",
+      "response": "response:tg:triples:{workspace}:{id}"}}, "triples-write:{id}":
+      {"topics": {"input": "flow:tg:triples-store:{workspace}:{id}"}}}, "interfaces":
+      {"agent": {"request": "request:tg:agent:{workspace}:{id}", "response": "response:tg:agent:{workspace}:{id}"},
+      "document-embeddings": {"request": "request:tg:document-embeddings:{workspace}:{id}",
+      "response": "response:tg:document-embeddings:{workspace}:{id}"}, "document-embeddings-store":
+      {"flow": "flow:tg:document-embeddings-store:{workspace}:{id}"}, "document-load":
+      {"flow": "flow:tg:document-load:{workspace}:{id}"}, "document-rag": {"request":
+      "request:tg:document-rag:{workspace}:{id}", "response": "response:tg:document-rag:{workspace}:{id}"},
+      "embeddings": {"request": "request:tg:embeddings:{workspace}:{id}", "response":
+      "response:tg:embeddings:{workspace}:{id}"}, "entity-contexts-load": {"flow":
+      "flow:tg:entity-contexts-load:{workspace}:{id}"}, "graph-embeddings": {"request":
+      "request:tg:graph-embeddings:{workspace}:{id}", "response": "response:tg:graph-embeddings:{workspace}:{id}"},
+      "graph-embeddings-store": {"flow": "flow:tg:graph-embeddings-store:{workspace}:{id}"},
+      "graph-rag": {"request": "request:tg:graph-rag:{workspace}:{id}", "response":
+      "response:tg:graph-rag:{workspace}:{id}"}, "mcp-tool": {"request": "request:tg:mcp-tool:{workspace}:{id}",
+      "response": "response:tg:mcp-tool:{workspace}:{id}"}, "nlp-query": {"request":
+      "request:tg:nlp-query:{workspace}:{id}", "response": "response:tg:nlp-query:{workspace}:{id}"},
+      "prompt": {"request": "request:tg:prompt:{workspace}:{id}", "response": "response:tg:prompt:{workspace}:{id}"},
+      "row-embeddings": {"request": "request:tg:row-embeddings:{workspace}:{id}",
+      "response": "response:tg:row-embeddings:{workspace}:{id}"}, "row-embeddings-store":
+      {"flow": "flow:tg:row-embeddings-store:{workspace}:{id}"}, "rows": {"request":
+      "request:tg:rows:{workspace}:{id}", "response": "response:tg:rows:{workspace}:{id}"},
+      "rows-store": {"flow": "flow:tg:rows-store:{workspace}:{id}"}, "sparql": {"request":
+      "request:tg:sparql:{workspace}:{id}", "response": "response:tg:sparql:{workspace}:{id}"},
+      "structured-diag": {"request": "request:tg:structured-diag:{workspace}:{id}",
+      "response": "response:tg:structured-diag:{workspace}:{id}"}, "structured-query":
+      {"request": "request:tg:structured-query:{workspace}:{id}", "response": "response:tg:structured-query:{workspace}:{id}"},
+      "text-completion": {"request": "request:tg:text-completion:{workspace}:{id}",
+      "response": "response:tg:text-completion:{workspace}:{id}"}, "text-load": {"flow":
+      "flow:tg:text-document-load:{workspace}:{id}"}, "triples": {"request": "request:tg:triples:{workspace}:{id}",
+      "response": "response:tg:triples:{workspace}:{id}"}, "triples-store": {"flow":
+      "flow:tg:triples-store:{workspace}:{id}"}}, "parameters": {"chunk-overlap":
       {"advanced": true, "description": "Chunk overlap", "order": 7, "type": "chunk-overlap"},
       "chunk-size": {"advanced": true, "description": "Chunk size", "order": 6, "type":
       "chunk-size"}, "embeddings-model": {"advanced": true, "description": "Embeddings
@@ -1914,72 +361,90 @@ items:
       "llm-temperature": {"advanced": true, "description": "LLM temperature", "order":
       3, "type": "llm-temperature"}}, "tags": ["document-rag", "graph-rag", "kgcore"]},
       "ontology": {"blueprint": {}, "description": "Ontology RAG + knowledge cores",
-      "flow": {"agent-manager:{id}": {"embeddings-request": "request:tg:embeddings:{id}",
-      "embeddings-response": "response:tg:embeddings:{id}", "explainability": "flow:tg:triples-store:{id}",
-      "graph-rag-request": "request:tg:graph-rag:{id}", "graph-rag-response": "response:tg:graph-rag:{id}",
-      "mcp-tool-request": "request:tg:mcp-tool:{id}", "mcp-tool-response": "response:tg:mcp-tool:{id}",
-      "next": "request:tg:agent:{id}", "prompt-request": "request:tg:prompt-rag:{id}",
-      "prompt-response": "response:tg:prompt-rag:{id}", "request": "request:tg:agent:{id}",
-      "response": "response:tg:agent:{id}", "row-embeddings-query-request": "request:tg:row-embeddings:{id}",
-      "row-embeddings-query-response": "response:tg:row-embeddings:{id}", "structured-query-request":
-      "request:tg:structured-query:{id}", "structured-query-response": "response:tg:structured-query:{id}",
-      "text-completion-request": "request:tg:text-completion:{id}", "text-completion-response":
-      "response:tg:text-completion:{id}"}, "chunker:{id}": {"chunk-overlap": "{chunk-overlap}",
-      "chunk-size": "{chunk-size}", "input": "flow:tg:text-document-load:{id}", "librarian-request":
-      "request:tg:librarian", "librarian-response": "request:tg:librarian", "output":
-      "flow:tg:chunk-load:{id}", "triples": "flow:tg:triples-store:{id}"}, "document-decoder:{id}":
-      {"input": "flow:tg:document-load:{id}", "librarian-request": "request:tg:librarian",
-      "librarian-response": "request:tg:librarian", "output": "flow:tg:text-document-load:{id}",
-      "triples": "flow:tg:triples-store:{id}"}, "embeddings:{id}": {"model": "{embeddings-model}",
-      "request": "request:tg:embeddings:{id}", "response": "response:tg:embeddings:{id}"},
-      "graph-embeddings-query:{id}": {"request": "request:tg:graph-embeddings:{id}",
-      "response": "response:tg:graph-embeddings:{id}"}, "graph-embeddings-write:{id}":
-      {"input": "flow:tg:graph-embeddings-store:{id}"}, "graph-embeddings:{id}": {"embeddings-request":
-      "request:tg:embeddings:{id}", "embeddings-response": "response:tg:embeddings:{id}",
-      "input": "flow:tg:entity-contexts-load:{id}", "output": "flow:tg:graph-embeddings-store:{id}"},
-      "graph-rag:{id}": {"embeddings-request": "request:tg:embeddings:{id}", "embeddings-response":
-      "response:tg:embeddings:{id}", "explainability": "flow:tg:triples-store:{id}",
-      "graph-embeddings-request": "request:tg:graph-embeddings:{id}", "graph-embeddings-response":
-      "response:tg:graph-embeddings:{id}", "librarian-request": "request:tg:librarian",
-      "librarian-response": "request:tg:librarian", "prompt-request": "request:tg:prompt-rag:{id}",
-      "prompt-response": "response:tg:prompt-rag:{id}", "request": "request:tg:graph-rag:{id}",
-      "response": "response:tg:graph-rag:{id}", "triples-request": "request:tg:triples:{id}",
-      "triples-response": "response:tg:triples:{id}"}, "kg-extract-ontology:{id}":
-      {"embeddings-request": "request:tg:embeddings:{id}", "embeddings-response":
-      "response:tg:embeddings:{id}", "entity-contexts": "flow:tg:entity-contexts-load:{id}",
-      "input": "flow:tg:chunk-load:{id}", "prompt-request": "request:tg:prompt:{id}",
-      "prompt-response": "response:tg:prompt:{id}", "triples": "flow:tg:triples-store:{id}"},
-      "kg-store:{id}": {"graph-embeddings-input": "flow:tg:graph-embeddings-store:{id}",
-      "triples-input": "flow:tg:triples-store:{id}"}, "mcp-tool:{id}": {"request":
-      "request:tg:mcp-tool:{id}", "response": "response:tg:mcp-tool:{id}", "text-completion-request":
-      "request:tg:text-completion:{id}", "text-completion-response": "response:tg:text-completion:{id}"},
-      "metering-rag:{id}": {"input": "response:tg:text-completion-rag:{id}"}, "metering:{id}":
-      {"input": "response:tg:text-completion:{id}"}, "prompt-rag:{id}": {"request":
-      "request:tg:prompt-rag:{id}", "response": "response:tg:prompt-rag:{id}", "text-completion-request":
-      "request:tg:text-completion-rag:{id}", "text-completion-response": "response:tg:text-completion-rag:{id}"},
-      "prompt:{id}": {"request": "request:tg:prompt:{id}", "response": "response:tg:prompt:{id}",
-      "text-completion-request": "request:tg:text-completion:{id}", "text-completion-response":
-      "response:tg:text-completion:{id}"}, "sparql-query:{id}": {"request": "request:tg:sparql:{id}",
-      "response": "response:tg:sparql:{id}", "triples-request": "request:tg:triples:{id}",
-      "triples-response": "response:tg:triples:{id}"}, "text-completion-rag:{id}":
-      {"model": "{llm-rag-model}", "request": "request:tg:text-completion-rag:{id}",
-      "response": "response:tg:text-completion-rag:{id}"}, "text-completion:{id}":
-      {"model": "{llm-model}", "request": "request:tg:text-completion:{id}", "response":
-      "response:tg:text-completion:{id}"}, "triples-query:{id}": {"request": "request:tg:triples:{id}",
-      "response": "response:tg:triples:{id}"}, "triples-write:{id}": {"input": "flow:tg:triples-store:{id}"}},
-      "interfaces": {"agent": {"request": "request:tg:agent:{id}", "response": "response:tg:agent:{id}"},
-      "document-load": "flow:tg:document-load:{id}", "embeddings": {"request": "request:tg:embeddings:{id}",
-      "response": "response:tg:embeddings:{id}"}, "entity-contexts-load": "flow:tg:entity-contexts-load:{id}",
-      "graph-embeddings": {"request": "request:tg:graph-embeddings:{id}", "response":
-      "response:tg:graph-embeddings:{id}"}, "graph-embeddings-store": "flow:tg:graph-embeddings-store:{id}",
-      "graph-rag": {"request": "request:tg:graph-rag:{id}", "response": "response:tg:graph-rag:{id}"},
-      "mcp-tool": {"request": "request:tg:mcp-tool:{id}", "response": "response:tg:mcp-tool:{id}"},
-      "prompt": {"request": "request:tg:prompt:{id}", "response": "response:tg:prompt:{id}"},
-      "sparql": {"request": "request:tg:sparql:{id}", "response": "response:tg:sparql:{id}"},
-      "text-completion": {"request": "request:tg:text-completion:{id}", "response":
-      "response:tg:text-completion:{id}"}, "text-load": "flow:tg:text-document-load:{id}",
-      "triples": {"request": "request:tg:triples:{id}", "response": "response:tg:triples:{id}"},
-      "triples-store": "flow:tg:triples-store:{id}"}, "parameters": {"chunk-overlap":
+      "flow": {"agent-manager:{id}": {"topics": {"embeddings-request": "request:tg:embeddings:{workspace}:{id}",
+      "embeddings-response": "response:tg:embeddings:{workspace}:{id}", "explainability":
+      "flow:tg:triples-store:{workspace}:{id}", "graph-rag-request": "request:tg:graph-rag:{workspace}:{id}",
+      "graph-rag-response": "response:tg:graph-rag:{workspace}:{id}", "librarian-request":
+      "request:tg:librarian:{workspace}", "librarian-response": "response:tg:librarian:{workspace}",
+      "mcp-tool-request": "request:tg:mcp-tool:{workspace}:{id}", "mcp-tool-response":
+      "response:tg:mcp-tool:{workspace}:{id}", "next": "request:tg:agent:{workspace}:{id}",
+      "prompt-request": "request:tg:prompt-rag:{workspace}:{id}", "prompt-response":
+      "response:tg:prompt-rag:{workspace}:{id}", "request": "request:tg:agent:{workspace}:{id}",
+      "response": "response:tg:agent:{workspace}:{id}", "row-embeddings-query-request":
+      "request:tg:row-embeddings:{workspace}:{id}", "row-embeddings-query-response":
+      "response:tg:row-embeddings:{workspace}:{id}", "structured-query-request": "request:tg:structured-query:{workspace}:{id}",
+      "structured-query-response": "response:tg:structured-query:{workspace}:{id}",
+      "text-completion-request": "request:tg:text-completion:{workspace}:{id}", "text-completion-response":
+      "response:tg:text-completion:{workspace}:{id}"}}, "chunker:{id}": {"parameters":
+      {"chunk-overlap": "{chunk-overlap}", "chunk-size": "{chunk-size}"}, "topics":
+      {"input": "flow:tg:text-document-load:{workspace}:{id}", "librarian-request":
+      "request:tg:librarian:{workspace}", "librarian-response": "response:tg:librarian:{workspace}",
+      "output": "flow:tg:chunk-load:{workspace}:{id}", "triples": "flow:tg:triples-store:{workspace}:{id}"}},
+      "document-decoder:{id}": {"topics": {"input": "flow:tg:document-load:{workspace}:{id}",
+      "librarian-request": "request:tg:librarian:{workspace}", "librarian-response":
+      "response:tg:librarian:{workspace}", "output": "flow:tg:text-document-load:{workspace}:{id}",
+      "triples": "flow:tg:triples-store:{workspace}:{id}"}}, "embeddings:{id}": {"parameters":
+      {"model": "{embeddings-model}"}, "topics": {"request": "request:tg:embeddings:{workspace}:{id}",
+      "response": "response:tg:embeddings:{workspace}:{id}"}}, "graph-embeddings-query:{id}":
+      {"topics": {"request": "request:tg:graph-embeddings:{workspace}:{id}", "response":
+      "response:tg:graph-embeddings:{workspace}:{id}"}}, "graph-embeddings-write:{id}":
+      {"topics": {"input": "flow:tg:graph-embeddings-store:{workspace}:{id}"}}, "graph-embeddings:{id}":
+      {"topics": {"embeddings-request": "request:tg:embeddings:{workspace}:{id}",
+      "embeddings-response": "response:tg:embeddings:{workspace}:{id}", "input": "flow:tg:entity-contexts-load:{workspace}:{id}",
+      "output": "flow:tg:graph-embeddings-store:{workspace}:{id}"}}, "graph-rag:{id}":
+      {"topics": {"embeddings-request": "request:tg:embeddings:{workspace}:{id}",
+      "embeddings-response": "response:tg:embeddings:{workspace}:{id}", "explainability":
+      "flow:tg:triples-store:{workspace}:{id}", "graph-embeddings-request": "request:tg:graph-embeddings:{workspace}:{id}",
+      "graph-embeddings-response": "response:tg:graph-embeddings:{workspace}:{id}",
+      "librarian-request": "request:tg:librarian:{workspace}", "librarian-response":
+      "response:tg:librarian:{workspace}", "prompt-request": "request:tg:prompt-rag:{workspace}:{id}",
+      "prompt-response": "response:tg:prompt-rag:{workspace}:{id}", "request": "request:tg:graph-rag:{workspace}:{id}",
+      "response": "response:tg:graph-rag:{workspace}:{id}", "triples-request": "request:tg:triples:{workspace}:{id}",
+      "triples-response": "response:tg:triples:{workspace}:{id}"}}, "kg-extract-ontology:{id}":
+      {"topics": {"embeddings-request": "request:tg:embeddings:{workspace}:{id}",
+      "embeddings-response": "response:tg:embeddings:{workspace}:{id}", "entity-contexts":
+      "flow:tg:entity-contexts-load:{workspace}:{id}", "input": "flow:tg:chunk-load:{workspace}:{id}",
+      "prompt-request": "request:tg:prompt:{workspace}:{id}", "prompt-response": "response:tg:prompt:{workspace}:{id}",
+      "triples": "flow:tg:triples-store:{workspace}:{id}"}}, "kg-store:{id}": {"topics":
+      {"graph-embeddings-input": "flow:tg:graph-embeddings-store:{workspace}:{id}",
+      "triples-input": "flow:tg:triples-store:{workspace}:{id}"}}, "mcp-tool:{id}":
+      {"topics": {"request": "request:tg:mcp-tool:{workspace}:{id}", "response": "response:tg:mcp-tool:{workspace}:{id}",
+      "text-completion-request": "request:tg:text-completion:{workspace}:{id}", "text-completion-response":
+      "response:tg:text-completion:{workspace}:{id}"}}, "metering-rag:{id}": {"topics":
+      {"input": "response:tg:text-completion-rag:{workspace}:{id}"}}, "metering:{id}":
+      {"topics": {"input": "response:tg:text-completion:{workspace}:{id}"}}, "prompt-rag:{id}":
+      {"topics": {"request": "request:tg:prompt-rag:{workspace}:{id}", "response":
+      "response:tg:prompt-rag:{workspace}:{id}", "text-completion-request": "request:tg:text-completion-rag:{workspace}:{id}",
+      "text-completion-response": "response:tg:text-completion-rag:{workspace}:{id}"}},
+      "prompt:{id}": {"topics": {"request": "request:tg:prompt:{workspace}:{id}",
+      "response": "response:tg:prompt:{workspace}:{id}", "text-completion-request":
+      "request:tg:text-completion:{workspace}:{id}", "text-completion-response": "response:tg:text-completion:{workspace}:{id}"}},
+      "sparql-query:{id}": {"topics": {"request": "request:tg:sparql:{workspace}:{id}",
+      "response": "response:tg:sparql:{workspace}:{id}", "triples-request": "request:tg:triples:{workspace}:{id}",
+      "triples-response": "response:tg:triples:{workspace}:{id}"}}, "text-completion-rag:{id}":
+      {"parameters": {"model": "{llm-rag-model}"}, "topics": {"request": "request:tg:text-completion-rag:{workspace}:{id}",
+      "response": "response:tg:text-completion-rag:{workspace}:{id}"}}, "text-completion:{id}":
+      {"parameters": {"model": "{llm-model}"}, "topics": {"request": "request:tg:text-completion:{workspace}:{id}",
+      "response": "response:tg:text-completion:{workspace}:{id}"}}, "triples-query:{id}":
+      {"topics": {"request": "request:tg:triples:{workspace}:{id}", "response": "response:tg:triples:{workspace}:{id}"}},
+      "triples-write:{id}": {"topics": {"input": "flow:tg:triples-store:{workspace}:{id}"}}},
+      "interfaces": {"agent": {"request": "request:tg:agent:{workspace}:{id}", "response":
+      "response:tg:agent:{workspace}:{id}"}, "document-load": {"flow": "flow:tg:document-load:{workspace}:{id}"},
+      "embeddings": {"request": "request:tg:embeddings:{workspace}:{id}", "response":
+      "response:tg:embeddings:{workspace}:{id}"}, "entity-contexts-load": {"flow":
+      "flow:tg:entity-contexts-load:{workspace}:{id}"}, "graph-embeddings": {"request":
+      "request:tg:graph-embeddings:{workspace}:{id}", "response": "response:tg:graph-embeddings:{workspace}:{id}"},
+      "graph-embeddings-store": {"flow": "flow:tg:graph-embeddings-store:{workspace}:{id}"},
+      "graph-rag": {"request": "request:tg:graph-rag:{workspace}:{id}", "response":
+      "response:tg:graph-rag:{workspace}:{id}"}, "mcp-tool": {"request": "request:tg:mcp-tool:{workspace}:{id}",
+      "response": "response:tg:mcp-tool:{workspace}:{id}"}, "prompt": {"request":
+      "request:tg:prompt:{workspace}:{id}", "response": "response:tg:prompt:{workspace}:{id}"},
+      "sparql": {"request": "request:tg:sparql:{workspace}:{id}", "response": "response:tg:sparql:{workspace}:{id}"},
+      "text-completion": {"request": "request:tg:text-completion:{workspace}:{id}",
+      "response": "response:tg:text-completion:{workspace}:{id}"}, "text-load": {"flow":
+      "flow:tg:text-document-load:{workspace}:{id}"}, "triples": {"request": "request:tg:triples:{workspace}:{id}",
+      "response": "response:tg:triples:{workspace}:{id}"}, "triples-store": {"flow":
+      "flow:tg:triples-store:{workspace}:{id}"}}, "parameters": {"chunk-overlap":
       {"advanced": true, "description": "Chunk overlap", "order": 7, "type": "chunk-overlap"},
       "chunk-size": {"advanced": true, "description": "Chunk size", "order": 6, "type":
       "chunk-size"}, "embeddings-model": {"advanced": true, "description": "Embeddings
@@ -1991,70 +456,86 @@ items:
       "llm-temperature": {"advanced": true, "description": "LLM temperature", "order":
       3, "type": "llm-temperature"}}, "tags": ["onto-rag", "kgcore"]}, "structured":
       {"blueprint": {}, "description": "Structured data extraction and querying",
-      "flow": {"agent-manager:{id}": {"embeddings-request": "request:tg:embeddings:{id}",
-      "embeddings-response": "response:tg:embeddings:{id}", "explainability": "flow:tg:triples-store:{id}",
-      "graph-rag-request": "request:tg:graph-rag:{id}", "graph-rag-response": "response:tg:graph-rag:{id}",
-      "mcp-tool-request": "request:tg:mcp-tool:{id}", "mcp-tool-response": "response:tg:mcp-tool:{id}",
-      "next": "request:tg:agent:{id}", "prompt-request": "request:tg:prompt-rag:{id}",
-      "prompt-response": "response:tg:prompt-rag:{id}", "request": "request:tg:agent:{id}",
-      "response": "response:tg:agent:{id}", "row-embeddings-query-request": "request:tg:row-embeddings:{id}",
-      "row-embeddings-query-response": "response:tg:row-embeddings:{id}", "structured-query-request":
-      "request:tg:structured-query:{id}", "structured-query-response": "response:tg:structured-query:{id}",
-      "text-completion-request": "request:tg:text-completion:{id}", "text-completion-response":
-      "response:tg:text-completion:{id}"}, "chunker:{id}": {"chunk-overlap": "{chunk-overlap}",
-      "chunk-size": "{chunk-size}", "input": "flow:tg:text-document-load:{id}", "librarian-request":
-      "request:tg:librarian", "librarian-response": "request:tg:librarian", "output":
-      "flow:tg:chunk-load:{id}", "triples": "flow:tg:triples-store:{id}"}, "document-decoder:{id}":
-      {"input": "flow:tg:document-load:{id}", "librarian-request": "request:tg:librarian",
-      "librarian-response": "request:tg:librarian", "output": "flow:tg:text-document-load:{id}",
-      "triples": "flow:tg:triples-store:{id}"}, "embeddings:{id}": {"model": "{embeddings-model}",
-      "request": "request:tg:embeddings:{id}", "response": "response:tg:embeddings:{id}"},
-      "kg-extract-rows:{id}": {"entity-contexts": "flow:tg:entity-contexts-load:{id}",
-      "input": "flow:tg:chunk-load:{id}", "output": "flow:tg:rows-store:{id}", "prompt-request":
-      "request:tg:prompt:{id}", "prompt-response": "response:tg:prompt:{id}"}, "mcp-tool:{id}":
-      {"request": "request:tg:mcp-tool:{id}", "response": "response:tg:mcp-tool:{id}",
-      "text-completion-request": "request:tg:text-completion:{id}", "text-completion-response":
-      "response:tg:text-completion:{id}"}, "metering-rag:{id}": {"input": "response:tg:text-completion-rag:{id}"},
-      "metering:{id}": {"input": "response:tg:text-completion:{id}"}, "nlp-query:{id}":
-      {"prompt-request": "request:tg:prompt-rag:{id}", "prompt-response": "response:tg:prompt-rag:{id}",
-      "request": "request:tg:nlp-query:{id}", "response": "response:tg:nlp-query:{id}"},
-      "prompt-rag:{id}": {"request": "request:tg:prompt-rag:{id}", "response": "response:tg:prompt-rag:{id}",
-      "text-completion-request": "request:tg:text-completion-rag:{id}", "text-completion-response":
-      "response:tg:text-completion-rag:{id}"}, "prompt:{id}": {"request": "request:tg:prompt:{id}",
-      "response": "response:tg:prompt:{id}", "text-completion-request": "request:tg:text-completion:{id}",
-      "text-completion-response": "response:tg:text-completion:{id}"}, "row-embeddings-query:{id}":
-      {"request": "request:tg:row-embeddings:{id}", "response": "response:tg:row-embeddings:{id}"},
-      "row-embeddings-write:{id}": {"input": "flow:tg:row-embeddings-store:{id}"},
-      "row-embeddings:{id}": {"embeddings-request": "request:tg:embeddings:{id}",
-      "embeddings-response": "response:tg:embeddings:{id}", "input": "flow:tg:rows-store:{id}",
-      "output": "flow:tg:row-embeddings-store:{id}"}, "rows-query:{id}": {"request":
-      "request:tg:rows:{id}", "response": "response:tg:rows:{id}"}, "rows-write:{id}":
-      {"input": "flow:tg:rows-store:{id}"}, "structured-diag:{id}": {"prompt-request":
-      "request:tg:prompt:{id}", "prompt-response": "response:tg:prompt:{id}", "request":
-      "request:tg:structured-diag:{id}", "response": "response:tg:structured-diag:{id}"},
-      "structured-query:{id}": {"nlp-query-request": "request:tg:nlp-query:{id}",
-      "nlp-query-response": "response:tg:nlp-query:{id}", "request": "request:tg:structured-query:{id}",
-      "response": "response:tg:structured-query:{id}", "rows-query-request": "request:tg:rows:{id}",
-      "rows-query-response": "response:tg:rows:{id}"}, "text-completion-rag:{id}":
-      {"model": "{llm-rag-model}", "request": "request:tg:text-completion-rag:{id}",
-      "response": "response:tg:text-completion-rag:{id}"}, "text-completion:{id}":
-      {"model": "{llm-model}", "request": "request:tg:text-completion:{id}", "response":
-      "response:tg:text-completion:{id}"}}, "interfaces": {"agent": {"request": "request:tg:agent:{id}",
-      "response": "response:tg:agent:{id}"}, "document-load": "flow:tg:document-load:{id}",
-      "embeddings": {"request": "request:tg:embeddings:{id}", "response": "response:tg:embeddings:{id}"},
-      "mcp-tool": {"request": "request:tg:mcp-tool:{id}", "response": "response:tg:mcp-tool:{id}"},
-      "nlp-query": {"request": "request:tg:nlp-query:{id}", "response": "response:tg:nlp-query:{id}"},
-      "prompt": {"request": "request:tg:prompt:{id}", "response": "response:tg:prompt:{id}"},
-      "row-embeddings": {"request": "request:tg:row-embeddings:{id}", "response":
-      "response:tg:row-embeddings:{id}"}, "row-embeddings-store": "flow:tg:row-embeddings-store:{id}",
-      "rows": {"request": "request:tg:rows:{id}", "response": "response:tg:rows:{id}"},
-      "rows-store": "flow:tg:rows-store:{id}", "structured-diag": {"request": "request:tg:structured-diag:{id}",
-      "response": "response:tg:structured-diag:{id}"}, "structured-query": {"request":
-      "request:tg:structured-query:{id}", "response": "response:tg:structured-query:{id}"},
-      "text-completion": {"request": "request:tg:text-completion:{id}", "response":
-      "response:tg:text-completion:{id}"}, "text-load": "flow:tg:text-document-load:{id}"},
-      "parameters": {"chunk-overlap": {"advanced": true, "description": "Chunk overlap",
-      "order": 7, "type": "chunk-overlap"}, "chunk-size": {"advanced": true, "description":
+      "flow": {"agent-manager:{id}": {"topics": {"embeddings-request": "request:tg:embeddings:{workspace}:{id}",
+      "embeddings-response": "response:tg:embeddings:{workspace}:{id}", "explainability":
+      "flow:tg:triples-store:{workspace}:{id}", "graph-rag-request": "request:tg:graph-rag:{workspace}:{id}",
+      "graph-rag-response": "response:tg:graph-rag:{workspace}:{id}", "librarian-request":
+      "request:tg:librarian:{workspace}", "librarian-response": "response:tg:librarian:{workspace}",
+      "mcp-tool-request": "request:tg:mcp-tool:{workspace}:{id}", "mcp-tool-response":
+      "response:tg:mcp-tool:{workspace}:{id}", "next": "request:tg:agent:{workspace}:{id}",
+      "prompt-request": "request:tg:prompt-rag:{workspace}:{id}", "prompt-response":
+      "response:tg:prompt-rag:{workspace}:{id}", "request": "request:tg:agent:{workspace}:{id}",
+      "response": "response:tg:agent:{workspace}:{id}", "row-embeddings-query-request":
+      "request:tg:row-embeddings:{workspace}:{id}", "row-embeddings-query-response":
+      "response:tg:row-embeddings:{workspace}:{id}", "structured-query-request": "request:tg:structured-query:{workspace}:{id}",
+      "structured-query-response": "response:tg:structured-query:{workspace}:{id}",
+      "text-completion-request": "request:tg:text-completion:{workspace}:{id}", "text-completion-response":
+      "response:tg:text-completion:{workspace}:{id}"}}, "chunker:{id}": {"parameters":
+      {"chunk-overlap": "{chunk-overlap}", "chunk-size": "{chunk-size}"}, "topics":
+      {"input": "flow:tg:text-document-load:{workspace}:{id}", "librarian-request":
+      "request:tg:librarian:{workspace}", "librarian-response": "response:tg:librarian:{workspace}",
+      "output": "flow:tg:chunk-load:{workspace}:{id}", "triples": "flow:tg:triples-store:{workspace}:{id}"}},
+      "document-decoder:{id}": {"topics": {"input": "flow:tg:document-load:{workspace}:{id}",
+      "librarian-request": "request:tg:librarian:{workspace}", "librarian-response":
+      "response:tg:librarian:{workspace}", "output": "flow:tg:text-document-load:{workspace}:{id}",
+      "triples": "flow:tg:triples-store:{workspace}:{id}"}}, "embeddings:{id}": {"parameters":
+      {"model": "{embeddings-model}"}, "topics": {"request": "request:tg:embeddings:{workspace}:{id}",
+      "response": "response:tg:embeddings:{workspace}:{id}"}}, "kg-extract-rows:{id}":
+      {"topics": {"entity-contexts": "flow:tg:entity-contexts-load:{workspace}:{id}",
+      "input": "flow:tg:chunk-load:{workspace}:{id}", "output": "flow:tg:rows-store:{workspace}:{id}",
+      "prompt-request": "request:tg:prompt:{workspace}:{id}", "prompt-response": "response:tg:prompt:{workspace}:{id}"}},
+      "mcp-tool:{id}": {"topics": {"request": "request:tg:mcp-tool:{workspace}:{id}",
+      "response": "response:tg:mcp-tool:{workspace}:{id}", "text-completion-request":
+      "request:tg:text-completion:{workspace}:{id}", "text-completion-response": "response:tg:text-completion:{workspace}:{id}"}},
+      "metering-rag:{id}": {"topics": {"input": "response:tg:text-completion-rag:{workspace}:{id}"}},
+      "metering:{id}": {"topics": {"input": "response:tg:text-completion:{workspace}:{id}"}},
+      "nlp-query:{id}": {"topics": {"prompt-request": "request:tg:prompt-rag:{workspace}:{id}",
+      "prompt-response": "response:tg:prompt-rag:{workspace}:{id}", "request": "request:tg:nlp-query:{workspace}:{id}",
+      "response": "response:tg:nlp-query:{workspace}:{id}"}}, "prompt-rag:{id}": {"topics":
+      {"request": "request:tg:prompt-rag:{workspace}:{id}", "response": "response:tg:prompt-rag:{workspace}:{id}",
+      "text-completion-request": "request:tg:text-completion-rag:{workspace}:{id}",
+      "text-completion-response": "response:tg:text-completion-rag:{workspace}:{id}"}},
+      "prompt:{id}": {"topics": {"request": "request:tg:prompt:{workspace}:{id}",
+      "response": "response:tg:prompt:{workspace}:{id}", "text-completion-request":
+      "request:tg:text-completion:{workspace}:{id}", "text-completion-response": "response:tg:text-completion:{workspace}:{id}"}},
+      "row-embeddings-query:{id}": {"topics": {"request": "request:tg:row-embeddings:{workspace}:{id}",
+      "response": "response:tg:row-embeddings:{workspace}:{id}"}}, "row-embeddings-write:{id}":
+      {"topics": {"input": "flow:tg:row-embeddings-store:{workspace}:{id}"}}, "row-embeddings:{id}":
+      {"topics": {"embeddings-request": "request:tg:embeddings:{workspace}:{id}",
+      "embeddings-response": "response:tg:embeddings:{workspace}:{id}", "input": "flow:tg:rows-store:{workspace}:{id}",
+      "output": "flow:tg:row-embeddings-store:{workspace}:{id}"}}, "rows-query:{id}":
+      {"topics": {"request": "request:tg:rows:{workspace}:{id}", "response": "response:tg:rows:{workspace}:{id}"}},
+      "rows-write:{id}": {"topics": {"input": "flow:tg:rows-store:{workspace}:{id}"}},
+      "structured-diag:{id}": {"topics": {"prompt-request": "request:tg:prompt:{workspace}:{id}",
+      "prompt-response": "response:tg:prompt:{workspace}:{id}", "request": "request:tg:structured-diag:{workspace}:{id}",
+      "response": "response:tg:structured-diag:{workspace}:{id}"}}, "structured-query:{id}":
+      {"topics": {"nlp-query-request": "request:tg:nlp-query:{workspace}:{id}", "nlp-query-response":
+      "response:tg:nlp-query:{workspace}:{id}", "request": "request:tg:structured-query:{workspace}:{id}",
+      "response": "response:tg:structured-query:{workspace}:{id}", "rows-query-request":
+      "request:tg:rows:{workspace}:{id}", "rows-query-response": "response:tg:rows:{workspace}:{id}"}},
+      "text-completion-rag:{id}": {"parameters": {"model": "{llm-rag-model}"}, "topics":
+      {"request": "request:tg:text-completion-rag:{workspace}:{id}", "response": "response:tg:text-completion-rag:{workspace}:{id}"}},
+      "text-completion:{id}": {"parameters": {"model": "{llm-model}"}, "topics": {"request":
+      "request:tg:text-completion:{workspace}:{id}", "response": "response:tg:text-completion:{workspace}:{id}"}}},
+      "interfaces": {"agent": {"request": "request:tg:agent:{workspace}:{id}", "response":
+      "response:tg:agent:{workspace}:{id}"}, "document-load": {"flow": "flow:tg:document-load:{workspace}:{id}"},
+      "embeddings": {"request": "request:tg:embeddings:{workspace}:{id}", "response":
+      "response:tg:embeddings:{workspace}:{id}"}, "mcp-tool": {"request": "request:tg:mcp-tool:{workspace}:{id}",
+      "response": "response:tg:mcp-tool:{workspace}:{id}"}, "nlp-query": {"request":
+      "request:tg:nlp-query:{workspace}:{id}", "response": "response:tg:nlp-query:{workspace}:{id}"},
+      "prompt": {"request": "request:tg:prompt:{workspace}:{id}", "response": "response:tg:prompt:{workspace}:{id}"},
+      "row-embeddings": {"request": "request:tg:row-embeddings:{workspace}:{id}",
+      "response": "response:tg:row-embeddings:{workspace}:{id}"}, "row-embeddings-store":
+      {"flow": "flow:tg:row-embeddings-store:{workspace}:{id}"}, "rows": {"request":
+      "request:tg:rows:{workspace}:{id}", "response": "response:tg:rows:{workspace}:{id}"},
+      "rows-store": {"flow": "flow:tg:rows-store:{workspace}:{id}"}, "structured-diag":
+      {"request": "request:tg:structured-diag:{workspace}:{id}", "response": "response:tg:structured-diag:{workspace}:{id}"},
+      "structured-query": {"request": "request:tg:structured-query:{workspace}:{id}",
+      "response": "response:tg:structured-query:{workspace}:{id}"}, "text-completion":
+      {"request": "request:tg:text-completion:{workspace}:{id}", "response": "response:tg:text-completion:{workspace}:{id}"},
+      "text-load": {"flow": "flow:tg:text-document-load:{workspace}:{id}"}}, "parameters":
+      {"chunk-overlap": {"advanced": true, "description": "Chunk overlap", "order":
+      7, "type": "chunk-overlap"}, "chunk-size": {"advanced": true, "description":
       "Chunk size", "order": 6, "type": "chunk-size"}, "embeddings-model": {"advanced":
       true, "description": "Embeddings model", "order": 5, "type": "embeddings-model"},
       "llm-model": {"advanced": false, "description": "LLM model", "order": 1, "type":
@@ -2783,38 +1264,50 @@ items:
       {"object-schema": {"properties": {"definition": {"type": "string"}, "entity":
       {"type": "string"}}, "required": ["entity", "definition"], "type": "object"},
       "prompt": "<instructions>\nStudy the following text and derive definitions for
-      any discovered entities.\nDo not provide definitions for entities whose definitions
-      are incomplete\nor unknown.\n\nOutput each definition as a separate JSON object
-      on its own line (JSONL format).\nEach object must have fields:\n- entity: the
-      name of the entity\n- definition: English text which defines the entity\n</instructions>\n\n<text>\n{{text}}\n</text>\n\n<requirements>\nOutput
+      any discovered entities. Do not provide definitions for entities whose definitions
+      are incomplete or unknown.\n\nGuidelines for high-quality definitions:\n- Capture
+      what distinguishes this entity from related entities\n- Include comparative
+      facts (e.g. more/less common, larger/smaller)\n- Include causal relationships
+      and classifications\n- Be specific \u2014 name related entities rather than
+      using vague references like \"other types\"\n\nOutput each definition as a separate
+      JSON object on its own line (JSONL format). Each object must have fields:\n-
+      entity: the name of the entity\n- definition: English text which defines the
+      entity\n</instructions>\n\n<text>\n{{text}}\n</text>\n\n<requirements>\nOutput
       format: JSONL (one JSON object per line, no array wrapper)\n- Each line must
       be a complete, valid JSON object\n- No commas between lines\n- No [ ] array
       brackets\n- No markdown formatting or prefixes\n- Do not use special characters
       in the definition text\n- Do not include null or unknown definitions\n\nExample
       output format:\n{\"entity\": \"photosynthesis\", \"definition\": \"The process
-      by which plants convert sunlight into energy\"}\n{\"entity\": \"chlorophyll\",
-      \"definition\": \"Green pigment in plants that absorbs light\"}\n</requirements>\n",
+      by which plants convert sunlight into energy\"}\n{\"entity\": \"melanoma\",
+      \"definition\": \"A type of skin cancer that is less common than basal cell
+      carcinoma and squamous cell carcinoma but tends to be more aggressive\"}\n</requirements>\n",
       "response-type": "jsonl"}, "template.extract-relationships": {"object-schema":
       {"properties": {"object": {"type": "string"}, "object-entity": {"type": "boolean"},
       "predicate": {"type": "string"}, "subject": {"type": "string"}}, "required":
       ["subject", "predicate", "object", "object-entity"], "type": "object"}, "prompt":
-      "<instructions>\nStudy the following text and derive entity relationships. For
-      each\nrelationship, derive the subject, predicate and object of the relationship.\n\nOutput
-      each relationship as a separate JSON object on its own line (JSONL format).\nEach
-      object must have fields:\n- subject: the subject of the relationship\n- predicate:
-      the predicate\n- object: the object of the relationship\n- object-entity: false
-      if the object is a simple data type (name, value, date). true if it is an entity.\n</instructions>\n\n<text>\n{{text}}\n</text>\n\n<requirements>\nOutput
-      format: JSONL (one JSON object per line, no array wrapper)\n- Each line must
-      be a complete, valid JSON object\n- No commas between lines\n- No [ ] array
-      brackets\n- No markdown formatting or prefixes\n- Do not use special characters
-      in the text fields\n\nExample output format:\n{\"subject\": \"Earth\", \"predicate\":
-      \"orbits\", \"object\": \"Sun\", \"object-entity\": true}\n{\"subject\": \"Earth\",
-      \"predicate\": \"has diameter\", \"object\": \"12742 km\", \"object-entity\":
-      false}\n</requirements>\n", "response-type": "jsonl"}, "template.extract-rows":
-      {"prompt": "<instructions>\nStudy the following text and derive objects which
-      match the schema provided.\n\nOutput each discovered object as a separate JSON
-      object on its own line (JSONL format).\nEach object''s fields must carry the
-      name field specified in the schema.\n</instructions>\n\n<schema>\n{{schema}}\n</schema>\n\n<text>\n{{text}}\n</text>\n\n<requirements>\nOutput
+      "<instructions>\nStudy the following text and extract important entity relationships.  For
+      each relationship, derive the subject, predicate and object.\n\nFocus on relationships
+      that capture key facts: definitions, causes, types, comparisons, properties,
+      and classifications.\n\nGuidelines for high-quality relationships:\n- Use specific,
+      meaningful predicates (avoid vague verbs like \"is\", \"has\", \"can be\")                                                           \n-
+      Resolve pronouns and references to their concrete entities\n- Prefer one clear
+      fact per relationship over compound statements\n- Skip trivial or self-evident
+      relationships\n</instructions>\n\n<text>\n{{text}}        \n</text>\n\n<requirements>\nOutput
+      format: JSONL (one JSON object per line, no array wrapper)\nEach object must
+      have fields:\n- subject: the subject of the relationship\n- predicate: the predicate\n-
+      object: the object of the relationship\n- object-entity: false if the object
+      is a simple data type (name, value, date). true if it is an entity.\n\n- Each
+      line must be a complete, valid JSON object\n- No commas between lines\n- No
+      [ ] array brackets\n- No markdown formatting or prefixes\n- Do not use special
+      characters in the text fields\n\nExample output format:\n{\"subject\": \"Earth\",
+      \"predicate\": \"orbits\", \"object\": \"Sun\", \"object-entity\": true}\n{\"subject\":
+      \"Earth\", \"predicate\": \"has diameter\", \"object\": \"12742 km\", \"object-entity\":
+      false}\n{\"subject\": \"basal cell carcinoma\", \"predicate\": \"is more common
+      than\", \"object\": \"melanoma\", \"object-entity\": true}\n</requirements>\n",
+      "response-type": "jsonl"}, "template.extract-rows": {"prompt": "<instructions>\nStudy
+      the following text and derive objects which match the schema provided.\n\nOutput
+      each discovered object as a separate JSON object on its own line (JSONL format).\nEach
+      object''s fields must carry the name field specified in the schema.\n</instructions>\n\n<schema>\n{{schema}}\n</schema>\n\n<text>\n{{text}}\n</text>\n\n<requirements>\nOutput
       format: JSONL (one JSON object per line, no array wrapper)\n- Each line must
       be a complete, valid JSON object matching the schema\n- No commas between lines\n-
       No [ ] array brackets\n- No markdown formatting or prefixes\n- Do not provide
@@ -2864,13 +1357,16 @@ items:
       %}\n\n## Text to Analyze\n\n{{text}}\n\n## Your Task\n\nExtract the following
       from the text above:\n\n1. **Entities**: Things mentioned in the text and their
       types\n2. **Relationships**: How entities relate to each other\n3. **Attributes**:
-      Properties of entities (like quantities, descriptions, etc.)\n\n## Output Format\n\nOutput
-      format: JSONL (one JSON object per line, no array wrapper)\nEach line must include
-      a \"type\" field to distinguish between entities, relationships, and attributes.\n\nFor
-      entities, output:\n{\"type\": \"entity\", \"entity\": \"entity name as it appears
-      in text\", \"entity_type\": \"EntityType\"}\n\nFor relationships, output:\n{\"type\":
-      \"relationship\", \"subject\": \"subject entity name\", \"subject_type\": \"SubjectType\",
-      \"relation\": \"relationship_name\", \"object\": \"object entity name\", \"object_type\":
+      Properties of entities (like quantities, descriptions, etc.)\n\n## Guidelines\n\n-
+      Resolve pronouns and vague references to their concrete entity names\n- Focus
+      on relationships that capture key facts: definitions, causes, types, comparisons,
+      and classifications\n\n## Output Format\n\nOutput format: JSONL (one JSON object
+      per line, no array wrapper)\nEach line must include a \"type\" field to distinguish
+      between entities, relationships, and attributes.\n\nFor entities, output:\n{\"type\":
+      \"entity\", \"entity\": \"entity name as it appears in text\", \"entity_type\":
+      \"EntityType\"}\n\nFor relationships, output:\n{\"type\": \"relationship\",
+      \"subject\": \"subject entity name\", \"subject_type\": \"SubjectType\", \"relation\":
+      \"relationship_name\", \"object\": \"object entity name\", \"object_type\":
       \"ObjectType\"}\n\nFor attributes, output:\n{\"type\": \"attribute\", \"entity\":
       \"entity name\", \"entity_type\": \"EntityType\", \"attribute\": \"attribute_name\",
       \"value\": \"literal value\"}\n\n## Important Rules\n\n1. **Entity names**:
@@ -2968,19 +1464,21 @@ items:
       No [ ] array brackets\n- No markdown formatting or prefixes\n- Do not provide
       explanations, only output JSONL\n\nExample output:\n{\"id\": \"a3f9b2c1\", \"score\":
       9}\n{\"id\": \"b7e2d4f9\", \"score\": 3}\n\nQuestion: {{query}}\n", "response-type":
-      "jsonl"}, "template.kg-prompt": {"prompt": "Study the following set of knowledge
-      statements. The statements are written in Cypher format that has been extracted
-      from a knowledge graph. Use only the provided set of knowledge statements in
-      your response. Do not speculate if the answer is not found in the provided set
-      of knowledge statements.\n\nHere''s the knowledge statements:\n{% for edge in
+      "jsonl"}, "template.kg-prompt": {"prompt": "Study the following knowledge statements
+      in Cypher format, extracted from a knowledge graph. Base your response only
+      on the provided statements. You may draw logical inferences by combining multiple
+      statements, but do not introduce outside knowledge.\n\nHere''s the knowledge
+      statements:\n{% for edge in knowledge %}({{edge.s}})-[{{edge.p}}]->({{edge.o}})\n{%endfor%}\n\nUse
+      only the provided knowledge statements to respond to the following:\n{{query}}\n",
+      "response-type": "text"}, "template.kg-synthesis": {"prompt": "Study the following
+      knowledge statements in Cypher format, extracted from a knowledge graph. Base
+      your response only on the provided statements. You may draw logical inferences
+      by combining multiple statements, but do not introduce outside knowledge. Answer
+      in natural language. Do not preface your response with references to the knowledge
+      statements as source of information.  Be concise, helpful and give as complete
+      an answer as possible.\n\nHere''s the knowledge statements:\n{% for edge in
       knowledge %}({{edge.s}})-[{{edge.p}}]->({{edge.o}})\n{%endfor%}\n\nUse only
       the provided knowledge statements to respond to the following:\n{{query}}\n",
-      "response-type": "text"}, "template.kg-synthesis": {"prompt": "Study the following
-      knowledge statements in Cypher format. Use only these provided statements in
-      your response. Do not speculate if the answer is not found in the provided statements.  Answer
-      in natural language.  Be helpful and give as complete an answer as possible.\n\nHere
-      are the knowledge statements:\n{% for edge in knowledge %}({{edge.s}})-[{{edge.p}}]->({{edge.o}})\n{%
-      endfor %}\n\nUse only the provided knowledge statements to respond to the following:\n{{query}}\n",
       "response-type": "text"}, "template.pattern-select": {"prompt": "Given the following
       user question and task type, select the best\nexecution pattern.\n\n## Task
       type\n\n{{ task_type }}: {{ task_type_description }}\n\n## Available patterns\n\n{%
@@ -3098,100 +1596,64 @@ items:
       "name": "LLM text completion", "type": "text-completion"}}}'
   kind: ConfigMap
   metadata:
-    name: trustgraph-cfg
+    name: template-cfg
     namespace: trustgraph
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
-      app: init-trustgraph
-    name: init-trustgraph
+      app: control
+    name: control
     namespace: trustgraph
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app: init-trustgraph
+        app: control
     template:
       metadata:
         labels:
-          app: init-trustgraph
+          app: control
       spec:
         containers:
         - command:
-          - tg-init-trustgraph
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --pulsar-admin-url
-          - http://pulsar:8080
-          - --config-file
-          - /trustgraph/config.json
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: init-trustgraph
+          - processor-group
+          - --log-level
+          - INFO
+          - -c
+          - /etc/trustgraph/launch/launch.yaml
+          env:
+          - name: IAM_BOOTSTRAP_TOKEN
+            valueFrom:
+              secretKeyRef:
+                key: token
+                name: iam-bootstrap-token
+          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          name: control
           resources:
             limits:
               cpu: '0.5'
-              memory: 128M
+              memory: 256M
             requests:
               cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
+              memory: 256M
           volumeMounts:
-          - mountPath: /trustgraph/
-            name: trustgraph-cfg
+          - mountPath: /etc/trustgraph/launch/
+            name: control-launch-cfg
+          - mountPath: /etc/trustgraph/template/
+            name: template-cfg
+        enableServiceLinks: false
         volumes:
         - configMap:
-            name: trustgraph-cfg
-          name: trustgraph-cfg
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: kg-extract-agent
-    name: kg-extract-agent
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: kg-extract-agent
-    template:
-      metadata:
-        labels:
-          app: kg-extract-agent
-      spec:
-        containers:
-        - command:
-          - kg-extract-agent
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --concurrency
-          - '1'
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: kg-extract-agent
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
+            name: control-launch-cfg
+          name: control-launch-cfg
+        - configMap:
+            name: template-cfg
+          name: template-cfg
 - apiVersion: v1
   kind: Service
   metadata:
-    name: kg-extract-agent
+    name: control
     namespace: trustgraph
   spec:
     ports:
@@ -3199,52 +1661,92 @@ items:
       port: 8000
       targetPort: 8000
     selector:
-      app: kg-extract-agent
+      app: control
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
-      app: kg-extract-definitions
-    name: kg-extract-definitions
+      app: ddg-mcp-server
+    name: ddg-mcp-server
     namespace: trustgraph
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app: kg-extract-definitions
+        app: ddg-mcp-server
     template:
       metadata:
         labels:
-          app: kg-extract-definitions
+          app: ddg-mcp-server
       spec:
         containers:
-        - command:
-          - kg-extract-definitions
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --concurrency
-          - '1'
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: kg-extract-definitions
+        - image: docker.io/trustgraph/ddg-mcp-server:0.1.0
+          name: ddg-mcp-server
+          ports:
+          - containerPort: 9870
+            hostPort: 9870
           resources:
             limits:
               cpu: '0.5'
-              memory: 128M
+              memory: 256M
             requests:
               cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
+              memory: 256M
+        enableServiceLinks: false
         volumes: []
 - apiVersion: v1
   kind: Service
   metadata:
-    name: kg-extract-definitions
+    name: ddg-mcp-server
+    namespace: trustgraph
+  spec:
+    ports:
+    - name: mcp
+      port: 9870
+      targetPort: 9870
+    selector:
+      app: ddg-mcp-server
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: document-decoder
+    name: document-decoder
+    namespace: trustgraph
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: document-decoder
+    template:
+      metadata:
+        labels:
+          app: document-decoder
+      spec:
+        containers:
+        - command:
+          - universal-decoder
+          - --pubsub-backend
+          - pulsar
+          - --pulsar-host
+          - pulsar://pulsar:6650
+          - --log-level
+          - INFO
+          image: docker.io/trustgraph/trustgraph-unstructured:2.4.29
+          name: document-decoder
+          resources:
+            limits:
+              cpu: '0.5'
+              memory: 512M
+            requests:
+              cpu: '0.1'
+              memory: 512M
+        enableServiceLinks: false
+        volumes: []
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: document-decoder
     namespace: trustgraph
   spec:
     ports:
@@ -3252,52 +1754,68 @@ items:
       port: 8000
       targetPort: 8000
     selector:
-      app: kg-extract-definitions
+      app: document-decoder
+- apiVersion: v1
+  data:
+    launch.yaml: "\"processors\":\n- \"class\": \"trustgraph.embeddings.fastembed.Processor\"\
+      \n  \"params\":\n    \"concurrency\": 1\n    \"id\": \"embeddings\"\n    \"\
+      pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n\
+      - \"class\": \"trustgraph.embeddings.document_embeddings.Processor\"\n  \"params\"\
+      :\n    \"id\": \"document-embeddings\"\n    \"pubsub_backend\": \"pulsar\"\n\
+      \    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.embeddings.graph_embeddings.Processor\"\
+      \n  \"params\":\n    \"id\": \"graph-embeddings\"\n    \"pubsub_backend\": \"\
+      pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.embeddings.row_embeddings.Processor\"\
+      \n  \"params\":\n    \"id\": \"row-embeddings\"\n    \"pubsub_backend\": \"\
+      pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\""
+  kind: ConfigMap
+  metadata:
+    name: embeddings-launch-cfg
+    namespace: trustgraph
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
-      app: kg-extract-ontology
-    name: kg-extract-ontology
+      app: embeddings
+    name: embeddings
     namespace: trustgraph
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app: kg-extract-ontology
+        app: embeddings
     template:
       metadata:
         labels:
-          app: kg-extract-ontology
+          app: embeddings
       spec:
         containers:
         - command:
-          - kg-extract-ontology
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --concurrency
-          - '1'
+          - processor-group
           - --log-level
           - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: kg-extract-ontology
+          - -c
+          - /etc/trustgraph/launch.yaml
+          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          name: embeddings
           resources:
             limits:
-              cpu: '0.5'
-              memory: 300M
+              cpu: '4.0'
+              memory: 640M
             requests:
-              cpu: '0.1'
-              memory: 300M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
+              cpu: '0.5'
+              memory: 640M
+          volumeMounts:
+          - mountPath: /etc/trustgraph/
+            name: embeddings-launch-cfg
+        enableServiceLinks: false
+        volumes:
+        - configMap:
+            name: embeddings-launch-cfg
+          name: embeddings-launch-cfg
 - apiVersion: v1
   kind: Service
   metadata:
-    name: kg-extract-ontology
+    name: embeddings
     namespace: trustgraph
   spec:
     ports:
@@ -3305,52 +1823,1069 @@ items:
       port: 8000
       targetPort: 8000
     selector:
-      app: kg-extract-ontology
+      app: embeddings
+- apiVersion: v1
+  data:
+    garage.toml: 'metadata_dir = "/var/lib/garage/meta"
+
+      data_dir = "/var/lib/garage/data"
+
+
+      db_engine = "lmdb"
+
+
+      replication_factor = 1
+
+
+      compression_level = 1
+
+
+      rpc_bind_addr = "[::]:3901"
+
+      rpc_public_addr = "[::]:3901"
+
+      rpc_secret = "bbba746a9e289bad64a9e7a36a4299dac8d6e0b8cc2a6c2937fe756df4492008"
+
+
+      [s3_api]
+
+      s3_region = "garage"
+
+      api_bind_addr = "[::]:3900"
+
+      root_domain = ".s3.garage.local"
+
+
+      [s3_web]
+
+      bind_addr = "[::]:3902"
+
+      root_domain = ".web.garage.local"
+
+      index = "index.html"
+
+
+      [k2v_api]
+
+      api_bind_addr = "[::]:3904"
+
+
+      [admin]
+
+      api_bind_addr = "[::]:3903"
+
+      admin_token = "batts-rockhearted-unpartially"
+
+      '
+  kind: ConfigMap
+  metadata:
+    name: garage-cfg
+    namespace: trustgraph
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: garage-meta
+    namespace: trustgraph
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 2G
+    storageClassName: tg
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: garage-data
+    namespace: trustgraph
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 5G
+    storageClassName: tg
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
-      app: kg-extract-relationships
-    name: kg-extract-relationships
+      app: garage
+    name: garage
     namespace: trustgraph
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app: kg-extract-relationships
+        app: garage
     template:
       metadata:
         labels:
-          app: kg-extract-relationships
+          app: garage
       spec:
         containers:
         - command:
-          - kg-extract-relationships
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --concurrency
-          - '1'
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: kg-extract-relationships
+          - /garage
+          - -c
+          - /etc/garage/garage.toml
+          - server
+          env:
+          - name: RUST_LOG
+            value: garage=info
+          image: docker.io/dxflrs/garage:v2.3.0
+          name: garage
+          ports:
+          - containerPort: 3900
+            hostPort: 3900
+          - containerPort: 3901
+            hostPort: 3901
+          - containerPort: 3902
+            hostPort: 3902
+          - containerPort: 3903
+            hostPort: 3903
+          - containerPort: 3904
+            hostPort: 3904
+          resources:
+            limits:
+              cpu: '1.0'
+              memory: 512M
+            requests:
+              cpu: '0.5'
+              memory: 512M
+          volumeMounts:
+          - mountPath: /etc/garage/
+            name: garage-cfg
+          - mountPath: /var/lib/garage/meta
+            name: garage-meta
+          - mountPath: /var/lib/garage/data
+            name: garage-data
+        enableServiceLinks: false
+        securityContext:
+          fsGroup: 1000
+        volumes:
+        - configMap:
+            name: garage-cfg
+          name: garage-cfg
+        - name: garage-meta
+          persistentVolumeClaim:
+            claimName: garage-meta
+        - name: garage-data
+          persistentVolumeClaim:
+            claimName: garage-data
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: garage-init
+    name: garage-init
+    namespace: trustgraph
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: garage-init
+    template:
+      metadata:
+        labels:
+          app: garage-init
+      spec:
+        containers:
+        - command:
+          - sh
+          - -c
+          - "set -e\n\n# Install required tools\necho \"Installing curl, jq and downloading\
+            \ garage CLI...\"\napk add --no-cache curl jq\n\n# Download garage binary\
+            \ (v2.1.0) for remote management\ncurl -fsSL \"https://garagehq.deuxfleurs.fr/_releases/v2.1.0/x86_64-unknown-linux-musl/garage\"\
+            \ \\\n    -o /usr/local/bin/garage\nchmod +x /usr/local/bin/garage\n\n\
+            echo \"Waiting for Garage daemon to be ready...\"\nMAX_ATTEMPTS=60\nATTEMPT=0\n\
+            # Wait for /health to respond (even 503 is fine - means daemon is up)\n\
+            until curl -s http://garage:3903/health >/dev/null 2>&1; do\n    ATTEMPT=$((ATTEMPT+1))\n\
+            \    if [ $ATTEMPT -ge $MAX_ATTEMPTS ]; then\n        echo \"ERROR: Garage\
+            \ failed to become ready after ${MAX_ATTEMPTS} attempts\"\n        exit\
+            \ 1\n    fi\n    echo \"Attempt ${ATTEMPT}/${MAX_ATTEMPTS}: Garage not\
+            \ ready, retrying in 2s...\"\n    sleep 2\ndone\necho \"Garage daemon\
+            \ is ready.\"\n\n# Get the node ID via v2 Admin API\necho \"Getting Garage\
+            \ node ID via Admin API...\"\ncurl -s -H \"Authorization: Bearer ${GARAGE_ADMIN_TOKEN}\"\
+            \ \\\n    \"http://garage:3903/v2/GetNodeInfo?node=self\" > /tmp/garage-node-info.json\n\
+            \n# Extract node ID from response (the key in success map is the node\
+            \ ID)\nNODE_ID=$(jq -r '.success | to_entries[0].value.nodeId' /tmp/garage-node-info.json)\n\
+            echo \"Node ID: ${NODE_ID}\"\n\nif [ -z \"$NODE_ID\" ] || [ \"$NODE_ID\"\
+            \ = \"null\" ]; then\n    echo \"ERROR: Failed to retrieve node ID\"\n\
+            \    exit 1\nfi\n\n# ===== LAYOUT MANAGEMENT VIA REMOTE RPC =====\n# Use\
+            \ garage CLI with -h and -s flags to connect remotely\n# -h requires format:\
+            \ <node-id>@<host>:<port>\n# -s provides the RPC secret\n\n# Construct\
+            \ full RPC identifier\nRPC_HOST=\"${NODE_ID}@garage:3901\"\necho \"RPC\
+            \ Host: ${RPC_HOST}\"\n\n# Check current layout to see if node is already\
+            \ assigned (idempotent)\necho \"Checking current cluster layout...\"\n\
+            LAYOUT_OUTPUT=$(garage -h \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\"\
+            \ layout show 2>&1)\n\n# Check if node already has a role assigned\n#\
+            \ Layout output shows abbreviated node ID (first 16 chars)\nNODE_ID_SHORT=\"\
+            ${NODE_ID:0:16}\"\nif echo \"$LAYOUT_OUTPUT\" | grep -q \"$NODE_ID_SHORT\"\
+            ; then\n    echo \"Node ${NODE_ID_SHORT}... already assigned in layout,\
+            \ skipping.\"\nelse\n    echo \"Assigning node to cluster layout...\"\n\
+            \    # Assign node to zone dc1 with configured capacity\n    garage -h\
+            \ \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\" \\\n        layout assign\
+            \ ${NODE_ID} -z dc1 -c ${GARAGE_DATA_SIZE}\n\n    echo \"Applying layout\
+            \ configuration...\"\n    # Get current staged version and apply\n   \
+            \ garage -h \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\" \\\n        layout\
+            \ apply --version 1\n\n    echo \"Layout configured successfully.\"\n\
+            \    # Wait for layout to stabilize\n    sleep 5\nfi\n\n# ===== KEY MANAGEMENT\
+            \ VIA REMOTE RPC =====\n\n# Check if key already exists (idempotent)\n\
+            # GARAGE_ACCESS_KEY is already a valid Garage Key ID (GK + 24 hex chars)\n\
+            if garage -h \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\" key info \"${GARAGE_ACCESS_KEY}\"\
+            \ >/dev/null 2>&1; then\n    echo \"Access key ${GARAGE_ACCESS_KEY} already\
+            \ exists, skipping creation.\"\nelse\n    echo \"Importing S3 access key:\
+            \ ${GARAGE_ACCESS_KEY}\"\n\n    # Import key with the provided credentials\
+            \ (both already in valid Garage format)\n    # GARAGE_ACCESS_KEY = Key\
+            \ ID (GK + 24 hex chars)\n    # GARAGE_SECRET_KEY = Secret (64 hex chars)\n\
+            \    garage -h \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\" \\\n      \
+            \  key import \"${GARAGE_ACCESS_KEY}\" \"${GARAGE_SECRET_KEY}\" --yes\n\
+            \n    echo \"Access key imported successfully.\"\nfi\n\n# Grant permissions\
+            \ to the key\necho \"Granting create-bucket permission to key...\"\ngarage\
+            \ -h \"${RPC_HOST}\" -s \"${GARAGE_RPC_SECRET}\" \\\n    key allow --create-bucket\
+            \ \"${GARAGE_ACCESS_KEY}\"\n\necho \"\"\necho \"Garage initialization\
+            \ complete!\"\necho \"S3 Endpoint: http://garage:3900\"\necho \"Region:\
+            \ ${GARAGE_REGION}\"\nexit 0\n"
+          env:
+          - name: GARAGE_ACCESS_KEY
+            value: GK000000000000000000000001
+          - name: GARAGE_ADMIN_TOKEN
+            value: batts-rockhearted-unpartially
+          - name: GARAGE_DATA_SIZE
+            value: 5G
+          - name: GARAGE_REGION
+            value: garage
+          - name: GARAGE_RPC_SECRET
+            value: bbba746a9e289bad64a9e7a36a4299dac8d6e0b8cc2a6c2937fe756df4492008
+          - name: GARAGE_SECRET_KEY
+            value: b171f00be9be4c32c734f4c05fe64c527a8ab5eb823b376cfa8c2531f70fc427
+          image: docker.io/alpine:3.23.2
+          name: garage-init
           resources:
             limits:
               cpu: '0.5'
-              memory: 128M
+              memory: 256M
             requests:
-              cpu: '0.1'
+              cpu: '0.25'
               memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
+          volumeMounts:
+          - mountPath: /etc/garage/
+            name: garage-cfg
+        enableServiceLinks: false
+        volumes:
+        - configMap:
+            name: garage-cfg
+          name: garage-cfg
 - apiVersion: v1
   kind: Service
   metadata:
-    name: kg-extract-relationships
+    name: garage
+    namespace: trustgraph
+  spec:
+    ports:
+    - name: s3-api
+      port: 3900
+      targetPort: 3900
+    - name: rpc
+      port: 3901
+      targetPort: 3901
+    - name: web
+      port: 3902
+      targetPort: 3902
+    - name: admin
+      port: 3903
+      targetPort: 3903
+    - name: k2v
+      port: 3904
+      targetPort: 3904
+    selector:
+      app: garage
+- apiVersion: v1
+  kind: PersistentVolumeClaim
+  metadata:
+    name: grafana-storage
+    namespace: trustgraph
+  spec:
+    accessModes:
+    - ReadWriteOnce
+    resources:
+      requests:
+        storage: 20G
+    storageClassName: tg
+- apiVersion: v1
+  data:
+    dashboard.yml: "\napiVersion: 1\n\nproviders:\n\n  - name: 'trustgraph.ai'\n \
+      \   orgId: 1\n    folder: 'TrustGraph'\n    folderUid: 'b6c5be90-d432-4df8-aeab-737c7b151228'\n\
+      \    type: file\n    disableDeletion: false\n    updateIntervalSeconds: 30\n\
+      \    allowUiUpdates: true\n    options:\n      path: /var/lib/grafana/dashboards\n\
+      \      foldersFromFilesStructure: false\n\n"
+  kind: ConfigMap
+  metadata:
+    name: prov-dash
+    namespace: trustgraph
+- apiVersion: v1
+  data:
+    datasource.yml: "apiVersion: 1\n\nprune: true\n\ndatasources:\n  - name: Prometheus\n\
+      \    type: prometheus\n    access: proxy\n    orgId: 1\n    # <string> Sets\
+      \ a custom UID to reference this\n    # data source in other parts of the configuration.\n\
+      \    # If not specified, Grafana generates one.\n    uid: 'f6b18033-5918-4e05-a1ca-4cb30343b129'\n\
+      \n    url: http://prometheus:9090\n\n    basicAuth: false\n    withCredentials:\
+      \ false\n    isDefault: true\n    editable: true\n\n  - name: Loki\n    type:\
+      \ loki\n    access: proxy\n    orgId: 1\n    # <string> Sets a custom UID to\
+      \ reference this\n    # data source in other parts of the configuration.\n \
+      \   # If not specified, Grafana generates one.\n    uid: 'cf6m73l5rnvuod'\n\n\
+      \    url: http://loki:3100\n\n    basicAuth: false\n    withCredentials: false\n\
+      \    editable: true\n\n"
+  kind: ConfigMap
+  metadata:
+    name: prov-data
+    namespace: trustgraph
+- apiVersion: v1
+  data:
+    log-dashboard.json: "{\n  \"annotations\": {\n    \"list\": [\n      {\n     \
+      \   \"builtIn\": 1,\n        \"datasource\": {\n          \"type\": \"grafana\"\
+      ,\n          \"uid\": \"-- Grafana --\"\n        },\n        \"enable\": true,\n\
+      \        \"hide\": true,\n        \"iconColor\": \"rgba(0, 211, 255, 1)\",\n\
+      \        \"name\": \"Annotations & Alerts\",\n        \"type\": \"dashboard\"\
+      \n      }\n    ]\n  },\n  \"editable\": true,\n  \"fiscalYearStartMonth\": 0,\n\
+      \  \"graphTooltip\": 0,\n  \"id\": 3,\n  \"links\": [],\n  \"panels\": [\n \
+      \   {\n      \"datasource\": {\n        \"type\": \"loki\",\n        \"uid\"\
+      : \"cf6m73l5rnvuod\"\n      },\n      \"fieldConfig\": {\n        \"defaults\"\
+      : {\n          \"color\": {\n            \"mode\": \"palette-classic\"\n   \
+      \       },\n          \"custom\": {\n            \"axisBorderShow\": false,\n\
+      \            \"axisCenteredZero\": false,\n            \"axisColorMode\": \"\
+      text\",\n            \"axisLabel\": \"\",\n            \"axisPlacement\": \"\
+      auto\",\n            \"fillOpacity\": 33,\n            \"gradientMode\": \"\
+      none\",\n            \"hideFrom\": {\n              \"legend\": false,\n   \
+      \           \"tooltip\": false,\n              \"viz\": false\n            },\n\
+      \            \"lineWidth\": 1,\n            \"scaleDistribution\": {\n     \
+      \         \"type\": \"linear\"\n            },\n            \"thresholdsStyle\"\
+      : {\n              \"mode\": \"off\"\n            }\n          },\n        \
+      \  \"mappings\": [],\n          \"thresholds\": {\n            \"mode\": \"\
+      absolute\",\n            \"steps\": [\n              {\n                \"color\"\
+      : \"green\",\n                \"value\": 0\n              },\n             \
+      \ {\n                \"color\": \"red\",\n                \"value\": 80\n  \
+      \            }\n            ]\n          }\n        },\n        \"overrides\"\
+      : []\n      },\n      \"gridPos\": {\n        \"h\": 6,\n        \"w\": 24,\n\
+      \        \"x\": 0,\n        \"y\": 0\n      },\n      \"id\": 2,\n      \"options\"\
+      : {\n        \"barRadius\": 0,\n        \"barWidth\": 0.97,\n        \"fullHighlight\"\
+      : false,\n        \"groupWidth\": 0.7,\n        \"legend\": {\n          \"\
+      calcs\": [],\n          \"displayMode\": \"list\",\n          \"placement\"\
+      : \"bottom\",\n          \"showLegend\": true\n        },\n        \"orientation\"\
+      : \"auto\",\n        \"showValue\": \"never\",\n        \"stacking\": \"normal\"\
+      ,\n        \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\"\
+      : \"single\",\n          \"sort\": \"none\"\n        },\n        \"xTickLabelRotation\"\
+      : 0,\n        \"xTickLabelSpacing\": 100\n      },\n      \"pluginVersion\"\
+      : \"12.1.1\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
+      \            \"type\": \"loki\",\n            \"uid\": \"cf6m73l5rnvuod\"\n\
+      \          },\n          \"direction\": \"backward\",\n          \"editorMode\"\
+      : \"code\",\n          \"expr\": \"topk(5, sum by (processor) (count_over_time({severity=~\\\
+      \"error|critical\\\"} [$__auto])))\",\n          \"queryType\": \"range\",\n\
+      \          \"refId\": \"A\"\n        }\n      ],\n      \"title\": \"Error volume\"\
+      ,\n      \"type\": \"barchart\"\n    },\n    {\n      \"datasource\": {\n  \
+      \      \"type\": \"loki\",\n        \"uid\": \"cf6m73l5rnvuod\"\n      },\n\
+      \      \"fieldConfig\": {\n        \"defaults\": {},\n        \"overrides\"\
+      : []\n      },\n      \"gridPos\": {\n        \"h\": 18,\n        \"w\": 24,\n\
+      \        \"x\": 0,\n        \"y\": 6\n      },\n      \"id\": 1,\n      \"options\"\
+      : {\n        \"dedupStrategy\": \"none\",\n        \"enableInfiniteScrolling\"\
+      : false,\n        \"enableLogDetails\": true,\n        \"prettifyLogMessage\"\
+      : false,\n        \"showCommonLabels\": false,\n        \"showLabels\": false,\n\
+      \        \"showTime\": false,\n        \"sortOrder\": \"Descending\",\n    \
+      \    \"wrapLogMessage\": true\n      },\n      \"pluginVersion\": \"12.1.1\"\
+      ,\n      \"targets\": [\n        {\n          \"datasource\": {\n          \
+      \  \"type\": \"loki\",\n            \"uid\": \"cf6m73l5rnvuod\"\n          },\n\
+      \          \"direction\": \"backward\",\n          \"editorMode\": \"builder\"\
+      ,\n          \"expr\": \"{severity=~\\\"error|critical\\\"} |= ``\",\n     \
+      \     \"queryType\": \"range\",\n          \"refId\": \"A\"\n        }\n   \
+      \   ],\n      \"title\": \"Log errors\",\n      \"type\": \"logs\"\n    }\n\
+      \  ],\n  \"preload\": false,\n  \"schemaVersion\": 41,\n  \"tags\": [],\n  \"\
+      templating\": {\n    \"list\": []\n  },\n  \"time\": {\n    \"from\": \"now-15m\"\
+      ,\n    \"to\": \"now\"\n  },\n  \"timepicker\": {},\n  \"timezone\": \"browser\"\
+      ,\n  \"title\": \"Logs\",\n  \"uid\": \"4bdce405-0dd3-4a14-9a8f-792152ebebba\"\
+      ,\n  \"version\": 13\n}\n"
+    overview-dashboard.json: "{\n  \"annotations\": {\n    \"list\": [\n      {\n\
+      \        \"builtIn\": 1,\n        \"datasource\": {\n          \"type\": \"\
+      grafana\",\n          \"uid\": \"-- Grafana --\"\n        },\n        \"enable\"\
+      : true,\n        \"hide\": true,\n        \"iconColor\": \"rgba(0, 211, 255,\
+      \ 1)\",\n        \"name\": \"Annotations & Alerts\",\n        \"type\": \"dashboard\"\
+      \n      }\n    ]\n  },\n  \"editable\": true,\n  \"fiscalYearStartMonth\": 0,\n\
+      \  \"graphTooltip\": 0,\n  \"id\": 5,\n  \"links\": [],\n  \"panels\": [\n \
+      \   {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"\
+      uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\"\
+      : {\n        \"defaults\": {\n          \"color\": {\n            \"mode\":\
+      \ \"palette-classic\"\n          },\n          \"custom\": {\n            \"\
+      axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n       \
+      \     \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n     \
+      \       \"axisPlacement\": \"auto\",\n            \"barAlignment\": 0,\n   \
+      \         \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\",\n \
+      \           \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n \
+      \           \"hideFrom\": {\n              \"legend\": false,\n            \
+      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
+      \       \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
+      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
+      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
+      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
+      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
+      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
+      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
+      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
+      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
+      \       {\n                \"color\": \"green\",\n                \"value\"\
+      : 0\n              },\n              {\n                \"color\": \"red\",\n\
+      \                \"value\": 80\n              }\n            ]\n          }\n\
+      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
+      \     \"h\": 7,\n        \"w\": 12,\n        \"x\": 0,\n        \"y\": 0\n \
+      \     },\n      \"id\": 17,\n      \"options\": {\n        \"legend\": {\n \
+      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
+      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
+      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
+      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
+      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"editorMode\": \"\
+      code\",\n          \"expr\": \"producer_count_total{processor=\\\"chunker\\\"\
+      ,name=\\\"output\\\"}\\n- ignoring(instance, job, processor, name, status)\\\
+      nprocessing_count_total{processor=\\\"kg-extract-relationships\\\", name=\\\"\
+      input\\\"}\",\n          \"legendFormat\": \"__auto\",\n          \"range\"\
+      : true,\n          \"refId\": \"A\"\n        }\n      ],\n      \"title\": \"\
+      Knowledge extraction backlog\",\n      \"type\": \"timeseries\"\n    },\n  \
+      \  {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"\
+      uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\"\
+      : {\n        \"defaults\": {\n          \"color\": {\n            \"mode\":\
+      \ \"palette-classic\"\n          },\n          \"custom\": {\n            \"\
+      axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n       \
+      \     \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n     \
+      \       \"axisPlacement\": \"auto\",\n            \"barAlignment\": 0,\n   \
+      \         \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\",\n \
+      \           \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n \
+      \           \"hideFrom\": {\n              \"legend\": false,\n            \
+      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
+      \       \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
+      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
+      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
+      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
+      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
+      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
+      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
+      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
+      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
+      \       {\n                \"color\": \"green\",\n                \"value\"\
+      : 0\n              },\n              {\n                \"color\": \"red\",\n\
+      \                \"value\": 80\n              }\n            ]\n          }\n\
+      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
+      \     \"h\": 7,\n        \"w\": 6,\n        \"x\": 12,\n        \"y\": 0\n \
+      \     },\n      \"id\": 19,\n      \"options\": {\n        \"legend\": {\n \
+      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
+      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
+      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
+      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
+      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"editorMode\": \"\
+      code\",\n          \"expr\": \"(producer_count_total{processor=\\\"graph-embeddings\\\
+      \",name=\\\"output\\\"} - ignoring(instance, job, processor, name, status) processing_count_total{processor=\\\
+      \"ge-write\\\",name=\\\"input\\\"} >= 2)\\nor\\n(0 * (producer_count_total{processor=\\\
+      \"graph-embeddings\\\",name=\\\"output\\\"} - ignoring(instance, job, processor,\
+      \ name, status) processing_count_total{processor=\\\"ge-write\\\",name=\\\"\
+      input\\\"}))\",\n          \"legendFormat\": \"__auto\",\n          \"range\"\
+      : true,\n          \"refId\": \"A\"\n        }\n      ],\n      \"title\": \"\
+      Graph embeddings backlog\",\n      \"type\": \"timeseries\"\n    },\n    {\n\
+      \      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"uid\"\
+      : \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\"\
+      : {\n        \"defaults\": {\n          \"color\": {\n            \"mode\":\
+      \ \"palette-classic\"\n          },\n          \"custom\": {\n            \"\
+      axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n       \
+      \     \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n     \
+      \       \"axisPlacement\": \"auto\",\n            \"barAlignment\": 0,\n   \
+      \         \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\",\n \
+      \           \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n \
+      \           \"hideFrom\": {\n              \"legend\": false,\n            \
+      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
+      \       \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
+      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
+      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
+      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
+      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
+      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
+      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
+      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
+      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
+      \       {\n                \"color\": \"green\",\n                \"value\"\
+      : 0\n              },\n              {\n                \"color\": \"red\",\n\
+      \                \"value\": 80\n              }\n            ]\n          }\n\
+      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
+      \     \"h\": 7,\n        \"w\": 6,\n        \"x\": 18,\n        \"y\": 0\n \
+      \     },\n      \"id\": 18,\n      \"options\": {\n        \"legend\": {\n \
+      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
+      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
+      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
+      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
+      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"editorMode\": \"\
+      code\",\n          \"expr\": \"(clamp_min(\\n  (\\n    producer_count_total{processor=\\\
+      \"kg-extract-definitions\\\",name=\\\"triples\\\"}\\n    + on(flow)\\n    producer_count_total{processor=\\\
+      \"kg-extract-relationships\\\",name=\\\"triples\\\"}\\n  )\\n  - on(flow) processing_count_total{processor=\\\
+      \"triples-write\\\",name=\\\"input\\\"},\\n  0\\n) >= 2) or (0 * clamp_min(\\\
+      n  (\\n    producer_count_total{processor=\\\"kg-extract-definitions\\\",name=\\\
+      \"triples\\\"}\\n    + on(flow)\\n    producer_count_total{processor=\\\"kg-extract-relationships\\\
+      \",name=\\\"triples\\\"}\\n  )\\n  - on(flow) processing_count_total{processor=\\\
+      \"triples-write\\\",name=\\\"input\\\"},\\n  0\\n))\",\n          \"legendFormat\"\
+      : \"__auto\",\n          \"range\": true,\n          \"refId\": \"A\"\n    \
+      \    }\n      ],\n      \"title\": \"Triples backlog\",\n      \"type\": \"\
+      timeseries\"\n    },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\"\
+      ,\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n   \
+      \   \"fieldConfig\": {\n        \"defaults\": {\n          \"custom\": {\n \
+      \           \"hideFrom\": {\n              \"legend\": false,\n            \
+      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
+      \       \"scaleDistribution\": {\n              \"type\": \"linear\"\n     \
+      \       }\n          }\n        },\n        \"overrides\": []\n      },\n  \
+      \    \"gridPos\": {\n        \"h\": 8,\n        \"w\": 12,\n        \"x\": 0,\n\
+      \        \"y\": 7\n      },\n      \"id\": 7,\n      \"options\": {\n      \
+      \  \"calculate\": false,\n        \"cellGap\": 1,\n        \"color\": {\n  \
+      \        \"exponent\": 0.5,\n          \"fill\": \"dark-orange\",\n        \
+      \  \"mode\": \"scheme\",\n          \"reverse\": false,\n          \"scale\"\
+      : \"exponential\",\n          \"scheme\": \"Oranges\",\n          \"steps\"\
+      : 64\n        },\n        \"exemplars\": {\n          \"color\": \"rgba(255,0,255,0.7)\"\
+      \n        },\n        \"filterValues\": {\n          \"le\": 1e-9\n        },\n\
+      \        \"legend\": {\n          \"show\": true\n        },\n        \"rowsFrame\"\
+      : {\n          \"layout\": \"auto\"\n        },\n        \"tooltip\": {\n  \
+      \        \"mode\": \"single\",\n          \"showColorScale\": false,\n     \
+      \     \"yHistogram\": false\n        },\n        \"yAxis\": {\n          \"\
+      axisPlacement\": \"left\",\n          \"reverse\": false\n        }\n      },\n\
+      \      \"pluginVersion\": \"12.3.0\",\n      \"targets\": [\n        {\n   \
+      \       \"datasource\": {\n            \"type\": \"prometheus\",\n         \
+      \   \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n          },\n      \
+      \    \"disableTextWrap\": false,\n          \"editorMode\": \"builder\",\n \
+      \         \"exemplar\": false,\n          \"expr\": \"sum by(le) (rate(text_completion_duration_bucket[$__rate_interval]))\"\
+      ,\n          \"format\": \"heatmap\",\n          \"fullMetaSearch\": false,\n\
+      \          \"includeNullMetadata\": true,\n          \"instant\": false,\n \
+      \         \"legendFormat\": \"99%\",\n          \"range\": true,\n         \
+      \ \"refId\": \"A\",\n          \"useBackend\": false\n        }\n      ],\n\
+      \      \"title\": \"LLM latency\",\n      \"type\": \"heatmap\"\n    },\n  \
+      \  {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n        \"\
+      uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\"\
+      : {\n        \"defaults\": {\n          \"custom\": {\n            \"hideFrom\"\
+      : {\n              \"legend\": false,\n              \"tooltip\": false,\n \
+      \             \"viz\": false\n            },\n            \"scaleDistribution\"\
+      : {\n              \"type\": \"linear\"\n            }\n          }\n      \
+      \  },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n        \"\
+      h\": 8,\n        \"w\": 12,\n        \"x\": 12,\n        \"y\": 7\n      },\n\
+      \      \"id\": 2,\n      \"options\": {\n        \"calculate\": false,\n   \
+      \     \"cellGap\": 5,\n        \"cellValues\": {\n          \"unit\": \"\"\n\
+      \        },\n        \"color\": {\n          \"exponent\": 0.5,\n          \"\
+      fill\": \"dark-orange\",\n          \"mode\": \"scheme\",\n          \"reverse\"\
+      : false,\n          \"scale\": \"exponential\",\n          \"scheme\": \"Oranges\"\
+      ,\n          \"steps\": 64\n        },\n        \"exemplars\": {\n         \
+      \ \"color\": \"rgba(255,0,255,0.7)\"\n        },\n        \"filterValues\":\
+      \ {\n          \"le\": 1e-9\n        },\n        \"legend\": {\n          \"\
+      show\": true\n        },\n        \"rowsFrame\": {\n          \"layout\": \"\
+      auto\"\n        },\n        \"tooltip\": {\n          \"mode\": \"single\",\n\
+      \          \"showColorScale\": false,\n          \"yHistogram\": false\n   \
+      \     },\n        \"yAxis\": {\n          \"axisLabel\": \"processing status\"\
+      ,\n          \"axisPlacement\": \"left\",\n          \"reverse\": false\n  \
+      \      }\n      },\n      \"pluginVersion\": \"12.3.0\",\n      \"targets\"\
+      : [\n        {\n          \"datasource\": {\n            \"type\": \"prometheus\"\
+      ,\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n         \
+      \ },\n          \"disableTextWrap\": false,\n          \"editorMode\": \"builder\"\
+      ,\n          \"exemplar\": false,\n          \"expr\": \"sum by(status) (rate(processing_count_total{status!=\\\
+      \"success\\\"}[$__rate_interval]))\",\n          \"format\": \"heatmap\",\n\
+      \          \"fullMetaSearch\": false,\n          \"includeNullMetadata\": true,\n\
+      \          \"instant\": false,\n          \"interval\": \"\",\n          \"\
+      legendFormat\": \"{{status}}\",\n          \"range\": true,\n          \"refId\"\
+      : \"A\",\n          \"useBackend\": false\n        }\n      ],\n      \"title\"\
+      : \"Error rate\",\n      \"type\": \"heatmap\"\n    },\n    {\n      \"datasource\"\
+      : {\n        \"type\": \"prometheus\",\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"\
+      color\": {\n            \"mode\": \"palette-classic\"\n          },\n      \
+      \    \"custom\": {\n            \"axisBorderShow\": false,\n            \"axisCenteredZero\"\
+      : false,\n            \"axisColorMode\": \"text\",\n            \"axisLabel\"\
+      : \"\",\n            \"axisPlacement\": \"auto\",\n            \"barAlignment\"\
+      : 0,\n            \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\"\
+      ,\n            \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n\
+      \            \"hideFrom\": {\n              \"legend\": false,\n           \
+      \   \"tooltip\": false,\n              \"viz\": false\n            },\n    \
+      \        \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
+      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
+      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
+      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
+      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
+      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
+      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
+      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
+      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
+      \       {\n                \"color\": \"green\",\n                \"value\"\
+      : 0\n              },\n              {\n                \"color\": \"red\",\n\
+      \                \"value\": 80\n              }\n            ]\n          }\n\
+      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
+      \     \"h\": 9,\n        \"w\": 12,\n        \"x\": 0,\n        \"y\": 15\n\
+      \      },\n      \"id\": 1,\n      \"options\": {\n        \"legend\": {\n \
+      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
+      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
+      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
+      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
+      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
+      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
+      : \"builder\",\n          \"expr\": \"sum by(processor) (rate(request_latency_count{processor!=\\\
+      \"config-svc\\\"}[$__rate_interval]))\",\n          \"fullMetaSearch\": false,\n\
+      \          \"includeNullMetadata\": true,\n          \"instant\": false,\n \
+      \         \"legendFormat\": \"{{job}}\",\n          \"range\": true,\n     \
+      \     \"refId\": \"A\",\n          \"useBackend\": false\n        }\n      ],\n\
+      \      \"title\": \"Request rate\",\n      \"type\": \"timeseries\"\n    },\n\
+      \    {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n       \
+      \ \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\"\
+      : {\n        \"defaults\": {\n          \"color\": {\n            \"mode\":\
+      \ \"palette-classic\"\n          },\n          \"custom\": {\n            \"\
+      axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n       \
+      \     \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n     \
+      \       \"axisPlacement\": \"auto\",\n            \"barAlignment\": 0,\n   \
+      \         \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\",\n \
+      \           \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n \
+      \           \"hideFrom\": {\n              \"legend\": false,\n            \
+      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
+      \       \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
+      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
+      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
+      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
+      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
+      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
+      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
+      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
+      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
+      \       {\n                \"color\": \"green\",\n                \"value\"\
+      : 0\n              },\n              {\n                \"color\": \"red\",\n\
+      \                \"value\": 80\n              }\n            ]\n          }\n\
+      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
+      \     \"h\": 9,\n        \"w\": 12,\n        \"x\": 12,\n        \"y\": 15\n\
+      \      },\n      \"id\": 5,\n      \"options\": {\n        \"legend\": {\n \
+      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
+      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
+      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
+      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
+      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
+      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
+      : \"builder\",\n          \"expr\": \"pulsar_msg_backlog{topic!=\\\"persistent://tg/config/config\\\
+      \"}\",\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\"\
+      : true,\n          \"instant\": false,\n          \"legendFormat\": \"{{topic}}\"\
+      ,\n          \"range\": true,\n          \"refId\": \"A\",\n          \"useBackend\"\
+      : false\n        }\n      ],\n      \"title\": \"Pub/sub backlog\",\n      \"\
+      type\": \"timeseries\"\n    },\n    {\n      \"datasource\": {\n        \"type\"\
+      : \"prometheus\",\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"\
+      color\": {\n            \"fixedColor\": \"semi-dark-green\",\n            \"\
+      mode\": \"palette-classic-by-name\"\n          },\n          \"custom\": {\n\
+      \            \"axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n\
+      \            \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n\
+      \            \"axisPlacement\": \"auto\",\n            \"fillOpacity\": 80,\n\
+      \            \"gradientMode\": \"none\",\n            \"hideFrom\": {\n    \
+      \          \"legend\": false,\n              \"tooltip\": false,\n         \
+      \     \"viz\": false\n            },\n            \"lineWidth\": 1,\n      \
+      \      \"scaleDistribution\": {\n              \"type\": \"linear\"\n      \
+      \      },\n            \"thresholdsStyle\": {\n              \"mode\": \"off\"\
+      \n            }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
+      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
+      \       {\n                \"color\": \"green\",\n                \"value\"\
+      : 0\n              },\n              {\n                \"color\": \"red\",\n\
+      \                \"value\": 80\n              }\n            ]\n          }\n\
+      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
+      \     \"h\": 7,\n        \"w\": 12,\n        \"x\": 0,\n        \"y\": 24\n\
+      \      },\n      \"id\": 10,\n      \"options\": {\n        \"barRadius\": 0,\n\
+      \        \"barWidth\": 0.97,\n        \"fullHighlight\": false,\n        \"\
+      groupWidth\": 0.7,\n        \"legend\": {\n          \"calcs\": [],\n      \
+      \    \"displayMode\": \"list\",\n          \"placement\": \"bottom\",\n    \
+      \      \"showLegend\": true\n        },\n        \"orientation\": \"auto\",\n\
+      \        \"showValue\": \"auto\",\n        \"stacking\": \"none\",\n       \
+      \ \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"single\"\
+      ,\n          \"sort\": \"none\"\n        },\n        \"xTickLabelRotation\"\
+      : 0,\n        \"xTickLabelSpacing\": 0\n      },\n      \"pluginVersion\": \"\
+      12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n  \
+      \          \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
+      : \"builder\",\n          \"exemplar\": false,\n          \"expr\": \"max by(le)\
+      \ (chunk_size_bucket)\",\n          \"format\": \"heatmap\",\n          \"fullMetaSearch\"\
+      : false,\n          \"includeNullMetadata\": false,\n          \"instant\":\
+      \ true,\n          \"legendFormat\": \"{{le}}\",\n          \"range\": false,\n\
+      \          \"refId\": \"A\",\n          \"useBackend\": false\n        }\n \
+      \     ],\n      \"title\": \"Chunk size\",\n      \"type\": \"barchart\"\n \
+      \   },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\",\n\
+      \        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n     \
+      \ \"fieldConfig\": {\n        \"defaults\": {\n          \"color\": {\n    \
+      \        \"mode\": \"palette-classic\"\n          },\n          \"custom\":\
+      \ {\n            \"axisBorderShow\": false,\n            \"axisCenteredZero\"\
+      : false,\n            \"axisColorMode\": \"text\",\n            \"axisLabel\"\
+      : \"\",\n            \"axisPlacement\": \"auto\",\n            \"barAlignment\"\
+      : 0,\n            \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\"\
+      ,\n            \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n\
+      \            \"hideFrom\": {\n              \"legend\": false,\n           \
+      \   \"tooltip\": false,\n              \"viz\": false\n            },\n    \
+      \        \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
+      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
+      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
+      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
+      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
+      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
+      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
+      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
+      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
+      \       {\n                \"color\": \"green\",\n                \"value\"\
+      : 0\n              },\n              {\n                \"color\": \"red\",\n\
+      \                \"value\": 80\n              }\n            ]\n          }\n\
+      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
+      \     \"h\": 7,\n        \"w\": 12,\n        \"x\": 12,\n        \"y\": 24\n\
+      \      },\n      \"id\": 11,\n      \"options\": {\n        \"legend\": {\n\
+      \          \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
+      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
+      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
+      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
+      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
+      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
+      : \"builder\",\n          \"exemplar\": false,\n          \"expr\": \"sum by(job)\
+      \ (increase(rate_limit_count_total[$__rate_interval]))\",\n          \"format\"\
+      : \"time_series\",\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\"\
+      : true,\n          \"instant\": false,\n          \"legendFormat\": \"{{instance}}\"\
+      ,\n          \"range\": true,\n          \"refId\": \"A\",\n          \"useBackend\"\
+      : false\n        }\n      ],\n      \"title\": \"Rate limit events\",\n    \
+      \  \"type\": \"timeseries\"\n    },\n    {\n      \"datasource\": {\n      \
+      \  \"type\": \"prometheus\",\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"\
+      color\": {\n            \"fixedColor\": \"light-blue\",\n            \"mode\"\
+      : \"palette-classic\"\n          },\n          \"custom\": {\n            \"\
+      axisBorderShow\": false,\n            \"axisCenteredZero\": false,\n       \
+      \     \"axisColorMode\": \"text\",\n            \"axisLabel\": \"\",\n     \
+      \       \"axisPlacement\": \"auto\",\n            \"barAlignment\": 0,\n   \
+      \         \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\",\n \
+      \           \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n \
+      \           \"hideFrom\": {\n              \"legend\": false,\n            \
+      \  \"tooltip\": false,\n              \"viz\": false\n            },\n     \
+      \       \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
+      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
+      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
+      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
+      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
+      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
+      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
+      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
+      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
+      \       {\n                \"color\": \"green\",\n                \"value\"\
+      : 0\n              },\n              {\n                \"color\": \"red\",\n\
+      \                \"value\": 80\n              }\n            ]\n          }\n\
+      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
+      \     \"h\": 8,\n        \"w\": 12,\n        \"x\": 0,\n        \"y\": 31\n\
+      \      },\n      \"id\": 12,\n      \"options\": {\n        \"legend\": {\n\
+      \          \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
+      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
+      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
+      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
+      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
+      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
+      : \"builder\",\n          \"expr\": \"rate(process_cpu_seconds_total[$__rate_interval])\"\
+      ,\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\":\
+      \ true,\n          \"instant\": false,\n          \"legendFormat\": \"{{instance}}\"\
+      ,\n          \"range\": true,\n          \"refId\": \"A\",\n          \"useBackend\"\
+      : false\n        }\n      ],\n      \"title\": \"CPU\",\n      \"type\": \"\
+      timeseries\"\n    },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\"\
+      ,\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n   \
+      \   \"fieldConfig\": {\n        \"defaults\": {\n          \"color\": {\n  \
+      \          \"mode\": \"palette-classic\"\n          },\n          \"custom\"\
+      : {\n            \"axisBorderShow\": false,\n            \"axisCenteredZero\"\
+      : false,\n            \"axisColorMode\": \"text\",\n            \"axisLabel\"\
+      : \"GB\",\n            \"axisPlacement\": \"auto\",\n            \"barAlignment\"\
+      : 0,\n            \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\"\
+      ,\n            \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n\
+      \            \"hideFrom\": {\n              \"legend\": false,\n           \
+      \   \"tooltip\": false,\n              \"viz\": false\n            },\n    \
+      \        \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
+      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
+      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
+      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
+      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
+      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
+      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
+      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
+      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
+      \       {\n                \"color\": \"green\",\n                \"value\"\
+      : 0\n              },\n              {\n                \"color\": \"red\",\n\
+      \                \"value\": 80\n              }\n            ]\n          }\n\
+      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
+      \     \"h\": 8,\n        \"w\": 12,\n        \"x\": 12,\n        \"y\": 31\n\
+      \      },\n      \"id\": 13,\n      \"options\": {\n        \"legend\": {\n\
+      \          \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
+      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
+      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
+      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
+      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
+      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
+      : \"builder\",\n          \"expr\": \"process_resident_memory_bytes / 1073741824\"\
+      ,\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\":\
+      \ true,\n          \"instant\": false,\n          \"legendFormat\": \"{{instance}}\"\
+      ,\n          \"range\": true,\n          \"refId\": \"A\",\n          \"useBackend\"\
+      : false\n        }\n      ],\n      \"title\": \"Memory\",\n      \"type\":\
+      \ \"timeseries\"\n    },\n    {\n      \"datasource\": {\n        \"uid\": \"\
+      f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n      \"fieldConfig\": {\n\
+      \        \"defaults\": {\n          \"color\": {\n            \"mode\": \"thresholds\"\
+      \n          },\n          \"custom\": {\n            \"align\": \"auto\",\n\
+      \            \"cellOptions\": {\n              \"type\": \"auto\"\n        \
+      \    },\n            \"footer\": {\n              \"reducers\": []\n       \
+      \     },\n            \"hideFrom\": {\n              \"viz\": false\n      \
+      \      },\n            \"inspect\": false\n          },\n          \"mappings\"\
+      : [],\n          \"thresholds\": {\n            \"mode\": \"absolute\",\n  \
+      \          \"steps\": [\n              {\n                \"color\": \"green\"\
+      ,\n                \"value\": 0\n              },\n              {\n       \
+      \         \"color\": \"red\",\n                \"value\": 80\n             \
+      \ }\n            ]\n          }\n        },\n        \"overrides\": []\n   \
+      \   },\n      \"gridPos\": {\n        \"h\": 7,\n        \"w\": 8,\n       \
+      \ \"x\": 0,\n        \"y\": 39\n      },\n      \"id\": 14,\n      \"options\"\
+      : {\n        \"cellHeight\": \"sm\",\n        \"showHeader\": true\n      },\n\
+      \      \"pluginVersion\": \"12.3.0\",\n      \"targets\": [\n        {\n   \
+      \       \"editorMode\": \"code\",\n          \"exemplar\": false,\n        \
+      \  \"expr\": \"sum by (model) (tokens_total)\",\n          \"format\": \"table\"\
+      ,\n          \"instant\": true,\n          \"legendFormat\": \"__auto\",\n \
+      \         \"range\": false,\n          \"refId\": \"A\"\n        }\n      ],\n\
+      \      \"title\": \"Models in use\",\n      \"transformations\": [\n       \
+      \ {\n          \"id\": \"organize\",\n          \"options\": {\n           \
+      \ \"excludeByName\": {\n              \"Time\": true\n            },\n     \
+      \       \"includeByName\": {},\n            \"indexByName\": {},\n         \
+      \   \"renameByName\": {}\n          }\n        }\n      ],\n      \"type\":\
+      \ \"table\"\n    },\n    {\n      \"datasource\": {\n        \"type\": \"prometheus\"\
+      ,\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\n      },\n   \
+      \   \"fieldConfig\": {\n        \"defaults\": {\n          \"color\": {\n  \
+      \          \"mode\": \"palette-classic\"\n          },\n          \"custom\"\
+      : {\n            \"axisBorderShow\": false,\n            \"axisCenteredZero\"\
+      : false,\n            \"axisColorMode\": \"text\",\n            \"axisLabel\"\
+      : \"\",\n            \"axisPlacement\": \"auto\",\n            \"barAlignment\"\
+      : 0,\n            \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\"\
+      ,\n            \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n\
+      \            \"hideFrom\": {\n              \"legend\": false,\n           \
+      \   \"tooltip\": false,\n              \"viz\": false\n            },\n    \
+      \        \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
+      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
+      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
+      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
+      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
+      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
+      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
+      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
+      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
+      \       {\n                \"color\": \"green\",\n                \"value\"\
+      : 0\n              },\n              {\n                \"color\": \"red\",\n\
+      \                \"value\": 80\n              }\n            ]\n          }\n\
+      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
+      \     \"h\": 7,\n        \"w\": 8,\n        \"x\": 8,\n        \"y\": 39\n \
+      \     },\n      \"id\": 15,\n      \"options\": {\n        \"legend\": {\n \
+      \         \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
+      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
+      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
+      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
+      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
+      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
+      : \"builder\",\n          \"expr\": \"sum by(model, direction)  (rate(tokens_total[$__rate_interval]))\"\
+      ,\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\":\
+      \ true,\n          \"instant\": false,\n          \"legendFormat\": \"{{model}}\
+      \ - {{direction}}\",\n          \"range\": true,\n          \"refId\": \"A\"\
+      ,\n          \"useBackend\": false\n        }\n      ],\n      \"title\": \"\
+      Tokens\",\n      \"type\": \"timeseries\"\n    },\n    {\n      \"datasource\"\
+      : {\n        \"type\": \"prometheus\",\n        \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n      },\n      \"fieldConfig\": {\n        \"defaults\": {\n          \"\
+      color\": {\n            \"mode\": \"palette-classic\"\n          },\n      \
+      \    \"custom\": {\n            \"axisBorderShow\": false,\n            \"axisCenteredZero\"\
+      : false,\n            \"axisColorMode\": \"text\",\n            \"axisLabel\"\
+      : \"$\",\n            \"axisPlacement\": \"auto\",\n            \"barAlignment\"\
+      : 0,\n            \"barWidthFactor\": 0.6,\n            \"drawStyle\": \"line\"\
+      ,\n            \"fillOpacity\": 0,\n            \"gradientMode\": \"none\",\n\
+      \            \"hideFrom\": {\n              \"legend\": false,\n           \
+      \   \"tooltip\": false,\n              \"viz\": false\n            },\n    \
+      \        \"insertNulls\": false,\n            \"lineInterpolation\": \"linear\"\
+      ,\n            \"lineWidth\": 1,\n            \"pointSize\": 5,\n          \
+      \  \"scaleDistribution\": {\n              \"type\": \"linear\"\n          \
+      \  },\n            \"showPoints\": \"auto\",\n            \"showValues\": false,\n\
+      \            \"spanNulls\": false,\n            \"stacking\": {\n          \
+      \    \"group\": \"A\",\n              \"mode\": \"none\"\n            },\n \
+      \           \"thresholdsStyle\": {\n              \"mode\": \"off\"\n      \
+      \      }\n          },\n          \"mappings\": [],\n          \"thresholds\"\
+      : {\n            \"mode\": \"absolute\",\n            \"steps\": [\n       \
+      \       {\n                \"color\": \"green\",\n                \"value\"\
+      : 0\n              },\n              {\n                \"color\": \"red\",\n\
+      \                \"value\": 80\n              }\n            ]\n          }\n\
+      \        },\n        \"overrides\": []\n      },\n      \"gridPos\": {\n   \
+      \     \"h\": 7,\n        \"w\": 8,\n        \"x\": 16,\n        \"y\": 39\n\
+      \      },\n      \"id\": 16,\n      \"options\": {\n        \"legend\": {\n\
+      \          \"calcs\": [],\n          \"displayMode\": \"list\",\n          \"\
+      placement\": \"bottom\",\n          \"showLegend\": true\n        },\n     \
+      \   \"tooltip\": {\n          \"hideZeros\": false,\n          \"mode\": \"\
+      single\",\n          \"sort\": \"none\"\n        }\n      },\n      \"pluginVersion\"\
+      : \"12.3.0\",\n      \"targets\": [\n        {\n          \"datasource\": {\n\
+      \            \"type\": \"prometheus\",\n            \"uid\": \"f6b18033-5918-4e05-a1ca-4cb30343b129\"\
+      \n          },\n          \"disableTextWrap\": false,\n          \"editorMode\"\
+      : \"builder\",\n          \"expr\": \"sum by(direction, model) (rate(tokens_total[$__rate_interval]))\"\
+      ,\n          \"fullMetaSearch\": false,\n          \"includeNullMetadata\":\
+      \ true,\n          \"instant\": false,\n          \"legendFormat\": \"{{model}}\
+      \ - {{direction}}\",\n          \"range\": true,\n          \"refId\": \"A\"\
+      ,\n          \"useBackend\": false\n        }\n      ],\n      \"title\": \"\
+      Token cost\",\n      \"type\": \"timeseries\"\n    }\n  ],\n  \"preload\": false,\n\
+      \  \"refresh\": \"5s\",\n  \"schemaVersion\": 42,\n  \"tags\": [],\n  \"templating\"\
+      : {\n    \"list\": []\n  },\n  \"time\": {\n    \"from\": \"now-1h\",\n    \"\
+      to\": \"now\"\n  },\n  \"timepicker\": {},\n  \"timezone\": \"\",\n  \"title\"\
+      : \"Overview (Pulsar)\",\n  \"uid\": \"ad77jv9\",\n  \"version\": 1\n}\n"
+  kind: ConfigMap
+  metadata:
+    name: dashboards
+    namespace: trustgraph
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: grafana
+    name: grafana
+    namespace: trustgraph
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: grafana
+    template:
+      metadata:
+        labels:
+          app: grafana
+      spec:
+        containers:
+        - env:
+          - name: GF_SECURITY_ADMIN_PASSWORD
+            valueFrom:
+              secretKeyRef:
+                key: password
+                name: grafana-secret
+          - name: GF_ANALYTICS_REPORT_WHATS_NEW
+            value: 'false'
+          - name: GF_DASHBOARDS_DEFAULT_HOME_DASHBOARD_PATH
+            value: /var/lib/grafana/dashboards/overview-dashboard.json
+          - name: GF_FEATURE_TOGGLES_ASSISTANT
+            value: 'false'
+          - name: GF_NEWS_NEWS_FEED_ENABLED
+            value: 'false'
+          - name: GF_ORG_NAME
+            value: trustgraph.ai
+          - name: GF_PANELS_DISABLE_NEWS_FEED
+            value: 'true'
+          - name: GF_PLUGINS_EXCLUDE_APPS
+            value: grafana-assistant-app
+          - name: GF_SECURITY_ADMIN_USER
+            value: admin
+          image: docker.io/grafana/grafana:13.0.1
+          name: grafana
+          ports:
+          - containerPort: 3000
+            hostPort: 3000
+          resources:
+            limits:
+              cpu: '1.0'
+              memory: 256M
+            requests:
+              cpu: '0.5'
+              memory: 256M
+          volumeMounts:
+          - mountPath: /var/lib/grafana
+            name: grafana-storage
+          - mountPath: /etc/grafana/provisioning/dashboards/
+            name: prov-dash
+          - mountPath: /etc/grafana/provisioning/datasources/
+            name: prov-data
+          - mountPath: /var/lib/grafana/dashboards/
+            name: dashboards
+        enableServiceLinks: false
+        securityContext:
+          fsGroup: 472
+        volumes:
+        - name: grafana-storage
+          persistentVolumeClaim:
+            claimName: grafana-storage
+        - configMap:
+            name: prov-dash
+          name: prov-dash
+        - configMap:
+            name: prov-data
+          name: prov-data
+        - configMap:
+            name: dashboards
+          name: dashboards
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: grafana
+    namespace: trustgraph
+  spec:
+    ports:
+    - name: http
+      port: 3000
+      targetPort: 3000
+    selector:
+      app: grafana
+- apiVersion: v1
+  data:
+    launch.yaml: "\"processors\":\n- \"class\": \"trustgraph.chunking.recursive.Processor\"\
+      \n  \"params\":\n    \"chunk_overlap\": 100\n    \"chunk_size\": 2000\n    \"\
+      id\": \"chunker\"\n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\":\
+      \ \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.extract.kg.definitions.Processor\"\
+      \n  \"params\":\n    \"concurrency\": 1\n    \"id\": \"kg-extract-definitions\"\
+      \n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
+      \n- \"class\": \"trustgraph.extract.kg.ontology.Processor\"\n  \"params\":\n\
+      \    \"concurrency\": 1\n    \"id\": \"kg-extract-ontology\"\n    \"pubsub_backend\"\
+      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"\
+      trustgraph.extract.kg.relationships.Processor\"\n  \"params\":\n    \"concurrency\"\
+      : 1\n    \"id\": \"kg-extract-relationships\"\n    \"pubsub_backend\": \"pulsar\"\
+      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.extract.kg.rows.Processor\"\
+      \n  \"params\":\n    \"concurrency\": 1\n    \"id\": \"kg-extract-rows\"\n \
+      \   \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
+      \n- \"class\": \"trustgraph.prompt.template.Processor\"\n  \"params\":\n   \
+      \ \"concurrency\": 1\n    \"id\": \"prompt\"\n    \"pubsub_backend\": \"pulsar\"\
+      \n    \"pulsar_host\": \"pulsar://pulsar:6650\""
+  kind: ConfigMap
+  metadata:
+    name: ingest-launch-cfg
+    namespace: trustgraph
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: ingest
+    name: ingest
+    namespace: trustgraph
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: ingest
+    template:
+      metadata:
+        labels:
+          app: ingest
+      spec:
+        containers:
+        - command:
+          - processor-group
+          - --log-level
+          - INFO
+          - -c
+          - /etc/trustgraph/launch.yaml
+          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          name: ingest
+          resources:
+            limits:
+              cpu: '0.5'
+              memory: 256M
+            requests:
+              cpu: '0.1'
+              memory: 256M
+          volumeMounts:
+          - mountPath: /etc/trustgraph/
+            name: ingest-launch-cfg
+        enableServiceLinks: false
+        volumes:
+        - configMap:
+            name: ingest-launch-cfg
+          name: ingest-launch-cfg
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: ingest
     namespace: trustgraph
   spec:
     ports:
@@ -3358,221 +2893,7 @@ items:
       port: 8000
       targetPort: 8000
     selector:
-      app: kg-extract-relationships
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: kg-extract-rows
-    name: kg-extract-rows
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: kg-extract-rows
-    template:
-      metadata:
-        labels:
-          app: kg-extract-rows
-      spec:
-        containers:
-        - command:
-          - kg-extract-rows
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --concurrency
-          - '1'
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: kg-extract-rows
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: kg-extract-rows
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: kg-extract-rows
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: kg-manager
-    name: kg-manager
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: kg-manager
-    template:
-      metadata:
-        labels:
-          app: kg-manager
-      spec:
-        containers:
-        - command:
-          - kg-manager
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: kg-manager
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: kg-manager
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: kg-manager
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: kg-store
-    name: kg-store
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: kg-store
-    template:
-      metadata:
-        labels:
-          app: kg-store
-      spec:
-        containers:
-        - command:
-          - kg-store
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: kg-store
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: kg-store
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: kg-store
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: librarian
-    name: librarian
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: librarian
-    template:
-      metadata:
-        labels:
-          app: librarian
-      spec:
-        containers:
-        - command:
-          - librarian
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          - --object-store-endpoint
-          - garage:3900
-          - --object-store-access-key
-          - GK000000000000000000000001
-          - --object-store-secret-key
-          - b171f00be9be4c32c734f4c05fe64c527a8ab5eb823b376cfa8c2531f70fc427
-          - --object-store-region
-          - garage
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: librarian
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 1024M
-            requests:
-              cpu: '0.1'
-              memory: 1024M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: librarian
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: librarian
+      app: ingest
 - apiVersion: v1
   data:
     local-config.yaml: "auth_enabled: false\n\nserver:\n  http_listen_port: 3100\n\
@@ -3629,7 +2950,7 @@ items:
           app: loki
       spec:
         containers:
-        - image: docker.io/grafana/loki:3.6.2
+        - image: docker.io/grafana/loki:3.7.2
           name: loki
           ports:
           - containerPort: 3100
@@ -3641,14 +2962,14 @@ items:
             requests:
               cpu: '0.1'
               memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
           volumeMounts:
           - mountPath: /etc/loki/
             name: loki-cfg
           - mountPath: /loki
             name: loki-data
+        enableServiceLinks: false
+        securityContext:
+          fsGroup: 10001
         volumes:
         - configMap:
             name: loki-cfg
@@ -3668,273 +2989,6 @@ items:
       targetPort: 3100
     selector:
       app: loki
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: mcp-server
-    name: mcp-server
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: mcp-server
-    template:
-      metadata:
-        labels:
-          app: mcp-server
-      spec:
-        containers:
-        - command:
-          - mcp-server
-          - --port
-          - '8000'
-          env:
-          - name: MCP_SERVER_SECRET
-            valueFrom:
-              secretKeyRef:
-                key: mcp-server-secret
-                name: mcp-server-secret
-          - name: GATEWAY_SECRET
-            valueFrom:
-              secretKeyRef:
-                key: gateway-secret
-                name: mcp-server-secret
-          image: docker.io/trustgraph/trustgraph-mcp:2.2.24
-          name: mcp-server
-          ports:
-          - containerPort: 8000
-            hostPort: 8000
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 256M
-            requests:
-              cpu: '0.1'
-              memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: mcp-server
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: mcp
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: mcp-server
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: mcp-tool
-    name: mcp-tool
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: mcp-tool
-    template:
-      metadata:
-        labels:
-          app: mcp-tool
-      spec:
-        containers:
-        - command:
-          - mcp-tool
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: mcp-tool
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: mcp-tool
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: mcp-tool
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: metering
-    name: metering
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: metering
-    template:
-      metadata:
-        labels:
-          app: metering
-      spec:
-        containers:
-        - command:
-          - metering
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: metering
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: metering
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: metering
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: metering-rag
-    name: metering-rag
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: metering-rag
-    template:
-      metadata:
-        labels:
-          app: metering-rag
-      spec:
-        containers:
-        - command:
-          - metering
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --id
-          - metering-rag
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: metering-rag
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: metering-rag
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: metering-rag
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: nlp-query
-    name: nlp-query
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: nlp-query
-    template:
-      metadata:
-        labels:
-          app: nlp-query
-      spec:
-        containers:
-        - command:
-          - nlp-query
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: nlp-query
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: nlp-query
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: nlp-query
 - apiVersion: v1
   data:
     prometheus.yml: "global:\n\n  scrape_interval:     15s # By default, scrape targets\
@@ -3943,69 +2997,26 @@ items:
       \ Alertmanager).\n  external_labels:\n    monitor: 'trustgraph'\n\n# A scrape\
       \ configuration containing exactly one endpoint to scrape:\n# Here it's Prometheus\
       \ itself.\nscrape_configs:\n\n  # The job name is added as a label `job=<job_name>`\
-      \ to any timeseries\n  # scraped from this config.\n\n  # TrustGraph services\n\
-      \n  - job_name: 'agent-manager'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'agent-manager:8000'\n\n  - job_name: 'api-gateway'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'api-gateway:8000'\n\
-      \n  - job_name: 'chunker'\n    scrape_interval: 5s\n    static_configs:\n  \
-      \    - targets:\n        - 'chunker:8000'\n\n  - job_name: 'config-svc'\n  \
-      \  scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'config-svc:8000'\n\
-      \n  - job_name: 'document-embeddings'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'document-embeddings:8000'\n\n  - job_name: 'document-rag'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'document-rag:8000'\n\
-      \n  - job_name: 'embeddings'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'embeddings:8000'\n\n  - job_name: 'graph-embeddings'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'graph-embeddings:8000'\n\
-      \n  - job_name: 'graph-rag'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'graph-rag:8000'\n\n  - job_name: 'kg-extract-agent'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'kg-extract-agent:8000'\n\
-      \n  - job_name: 'kg-extract-definitions'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'kg-extract-definitions:8000'\n\n  - job_name:\
-      \ 'kg-extract-objects'\n    scrape_interval: 5s\n    static_configs:\n     \
-      \ - targets:\n        - 'kg-extract-objects:8000'\n\n  - job_name: 'kg-extract-relationships'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'kg-extract-relationships:8000'\n\
-      \n  - job_name: 'kg-extract-ontology'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'kg-extract-ontology:8000'\n\n  - job_name: 'kg-manager'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'kg-manager:8000'\n\
-      \n  - job_name: 'kg-store'\n    scrape_interval: 5s\n    static_configs:\n \
-      \     - targets:\n        - 'kg-store:8000'\n\n  - job_name: 'librarian'\n \
-      \   scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'librarian:8000'\n\
-      \n  - job_name: 'mcp-server'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'mcp-server:8000'\n\n  - job_name: 'mcp-tool'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'mcp-tool:8000'\n\
-      \n  - job_name: 'metering'\n    scrape_interval: 5s\n    static_configs:\n \
-      \     - targets:\n        - 'metering:8000'\n\n  - job_name: 'metering-rag'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'metering-rag:8000'\n\
-      \n  - job_name: 'nlp-query'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'nlp-query:8000'\n\n  - job_name: 'pdf-decoder'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'pdf-decoder:8000'\n\
-      \n  - job_name: 'prompt'\n    scrape_interval: 5s\n    static_configs:\n   \
-      \   - targets:\n        - 'prompt:8000'\n\n  - job_name: 'prompt-rag'\n    scrape_interval:\
-      \ 5s\n    static_configs:\n      - targets:\n        - 'prompt-rag:8000'\n\n\
-      \  - job_name: 'query-doc-embeddings'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'query-doc-embeddings:8000'\n\n  - job_name: 'query-graph-embeddings'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'query-graph-embeddings:8000'\n\
-      \n  - job_name: 'query-row-embeddings'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'query-row-embeddings:8000'\n\n  - job_name: 'query-rows'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'query-rows:8000'\n\
-      \n  - job_name: 'query-triples'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'query-triples:8000'\n\n  - job_name: 'row-embeddings'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'row-embeddings:8000'\n\
-      \n  - job_name: 'store-doc-embeddings'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'store-doc-embeddings:8000'\n\n  - job_name: 'store-graph-embeddings'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'store-graph-embeddings:8000'\n\
-      \n  - job_name: 'store-row-embeddings'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'store-row-embeddings:8000'\n\n  - job_name: 'store-rows'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'store-rows:8000'\n\
-      \n  - job_name: 'store-triples'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'store-triples:8000'\n\n  - job_name: 'structured-query'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'structured-query:8000'\n\
-      \n  - job_name: 'structured-diag'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'structured-diag:8000'\n\n  - job_name: 'text-completion'\n\
-      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'text-completion:8000'\n\
-      \n  - job_name: 'text-completion-rag'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'text-completion-rag:8000'\n\n  # Non-Trustgraph\
-      \ services\n  - job_name: 'garage'\n    metrics_path: '/metrics'\n    scrape_interval:\
+      \ to any timeseries\n  # scraped from this config.\n\n  # TrustGraph services\
+      \ in processor groups\n  - job_name: 'control'\n    scrape_interval: 5s\n  \
+      \  static_configs:\n      - targets:\n        - 'control:8000'\n\n  - job_name:\
+      \ 'ingest'\n    scrape_interval: 5s\n    static_configs:\n      - targets:\n\
+      \        - 'ingest:8000'\n\n  - job_name: 'rag'\n    scrape_interval: 5s\n \
+      \   static_configs:\n      - targets:\n        - 'rag:8000'\n\n  - job_name:\
+      \ 'embeddings'\n    scrape_interval: 5s\n    static_configs:\n      - targets:\n\
+      \        - 'embeddings:8000'\n\n  - job_name: 'vector-store'\n    scrape_interval:\
+      \ 5s\n    static_configs:\n      - targets:\n        - 'vector-store:8000'\n\
+      \n  - job_name: 'row-store'\n    scrape_interval: 5s\n    static_configs:\n\
+      \      - targets:\n        - 'row-store:8000'\n\n  - job_name: 'triple-store'\n\
+      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'triple-store:8000'\n\
+      \n  - job_name: 'text-completion'\n    scrape_interval: 5s\n    static_configs:\n\
+      \      - targets:\n        - 'text-completion:8000'\n\n  # TrustGraph services\
+      \ standalone\n  - job_name: 'api-gateway'\n    scrape_interval: 5s\n    static_configs:\n\
+      \      - targets:\n        - 'api-gateway:8000'\n\n  - job_name: 'mcp-server'\n\
+      \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'mcp-server:8000'\n\
+      \n  - job_name: 'document-decoder'\n    scrape_interval: 5s\n    static_configs:\n\
+      \      - targets:\n        - 'document-decoder:8000'\n\n  # Non-Trustgraph services\n\
+      \  - job_name: 'garage'\n    metrics_path: '/metrics'\n    scrape_interval:\
       \ 5s\n    static_configs:\n      - targets:\n        - 'garage:3903'\n\n  -\
       \ job_name: 'pulsar'\n    scrape_interval: 5s\n    static_configs:\n      -\
       \ targets:\n        - 'pulsar:8080'\n"
@@ -4043,7 +3054,7 @@ items:
           app: prometheus
       spec:
         containers:
-        - image: docker.io/prom/prometheus:v3.8.0
+        - image: docker.io/prom/prometheus:v3.11.3
           name: prometheus
           ports:
           - containerPort: 9090
@@ -4055,14 +3066,14 @@ items:
             requests:
               cpu: '0.1'
               memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
           volumeMounts:
           - mountPath: /etc/prometheus/
             name: prometheus-cfg
           - mountPath: /prometheus
             name: prometheus-data
+        enableServiceLinks: false
+        securityContext:
+          fsGroup: 65534
         volumes:
         - configMap:
             name: prometheus-cfg
@@ -4082,114 +3093,6 @@ items:
       targetPort: 9090
     selector:
       app: prometheus
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: prompt
-    name: prompt
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: prompt
-    template:
-      metadata:
-        labels:
-          app: prompt
-      spec:
-        containers:
-        - command:
-          - prompt-template
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --concurrency
-          - '1'
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: prompt
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: prompt
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: prompt
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: prompt-rag
-    name: prompt-rag
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: prompt-rag
-    template:
-      metadata:
-        labels:
-          app: prompt-rag
-      spec:
-        containers:
-        - command:
-          - prompt-template
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --id
-          - prompt-rag
-          - --concurrency
-          - '1'
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: prompt-rag
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: prompt-rag
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: prompt-rag
 - apiVersion: v1
   kind: PersistentVolumeClaim
   metadata:
@@ -4242,7 +3145,7 @@ items:
             value: -Xms256m -Xmx256m -XX:MaxDirectMemorySize=256m
           - name: metadataStoreUrl
             value: zk:zookeeper:2181
-          image: docker.io/apachepulsar/pulsar:4.1.0
+          image: docker.io/apachepulsar/pulsar:4.2.1
           name: zookeeper
           ports:
           - containerPort: 2181
@@ -4258,12 +3161,12 @@ items:
             requests:
               cpu: '0.05'
               memory: 512M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
           volumeMounts:
-          - mountPath: /pulsar/data/zookeeper
+          - mountPath: /pulsar/data
             name: zookeeper
+        enableServiceLinks: false
+        securityContext:
+          fsGroup: 1000
         volumes:
         - name: zookeeper
           persistentVolumeClaim:
@@ -4295,7 +3198,7 @@ items:
           env:
           - name: PULSAR_MEM
             value: -Xms128m -Xmx128m -XX:MaxDirectMemorySize=128m
-          image: docker.io/apachepulsar/pulsar:4.1.0
+          image: docker.io/apachepulsar/pulsar:4.2.1
           name: pulsar-init
           resources:
             limits:
@@ -4304,9 +3207,7 @@ items:
             requests:
               cpu: '0.05'
               memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
+        enableServiceLinks: false
         volumes: []
 - apiVersion: apps/v1
   kind: Deployment
@@ -4329,10 +3230,11 @@ items:
         - command:
           - bash
           - -c
-          - bin/apply-config-from-env.py conf/bookkeeper.conf && exec bin/pulsar bookie
+          - sleep 2 && bin/apply-config-from-env.py conf/bookkeeper.conf && exec bin/pulsar
+            bookie
           env:
           - name: BOOKIE_MEM
-            value: -Xms512m -Xmx512m -XX:MaxDirectMemorySize=512m
+            value: -Xms256m -Xmx256m -XX:MaxDirectMemorySize=256m
           - name: advertisedAddress
             value: bookie
           - name: bookieId
@@ -4343,7 +3245,7 @@ items:
             value: metadata-store:zk:zookeeper:2181
           - name: zkServers
             value: zookeeper:2181
-          image: docker.io/apachepulsar/pulsar:4.1.0
+          image: docker.io/apachepulsar/pulsar:4.2.1
           name: bookie
           ports:
           - containerPort: 3181
@@ -4351,16 +3253,16 @@ items:
           resources:
             limits:
               cpu: '1'
-              memory: 2048M
+              memory: 1024M
             requests:
               cpu: '0.1'
-              memory: 2048M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
+              memory: 1024M
           volumeMounts:
-          - mountPath: /pulsar/data/bookkeeper
+          - mountPath: /pulsar/data
             name: bookie
+        enableServiceLinks: false
+        securityContext:
+          fsGroup: 1000
         volumes:
         - name: bookie
           persistentVolumeClaim:
@@ -4389,7 +3291,7 @@ items:
           - bin/apply-config-from-env.py conf/broker.conf && exec bin/pulsar broker
           env:
           - name: PULSAR_MEM
-            value: -Xms512m -Xmx512m -XX:MaxDirectMemorySize=512m
+            value: -Xms384m -Xmx384m -XX:MaxDirectMemorySize=384m
           - name: advertisedAddress
             value: pulsar
           - name: advertisedListeners
@@ -4406,7 +3308,7 @@ items:
             value: zk:zookeeper:2181
           - name: zookeeperServers
             value: zookeeper:2181
-          image: docker.io/apachepulsar/pulsar:4.1.0
+          image: docker.io/apachepulsar/pulsar:4.2.1
           name: pulsar
           ports:
           - containerPort: 6650
@@ -4416,13 +3318,11 @@ items:
           resources:
             limits:
               cpu: '1'
-              memory: 1500M
+              memory: 800M
             requests:
               cpu: '0.1'
-              memory: 1500M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
+              memory: 800M
+        enableServiceLinks: false
         volumes: []
 - apiVersion: v1
   kind: Service
@@ -4499,7 +3399,7 @@ items:
           app: qdrant
       spec:
         containers:
-        - image: docker.io/qdrant/qdrant:v1.15.4
+        - image: docker.io/qdrant/qdrant:v1.18.0
           name: qdrant
           ports:
           - containerPort: 6333
@@ -4513,12 +3413,12 @@ items:
             requests:
               cpu: '0.5'
               memory: 1024M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
           volumeMounts:
           - mountPath: /qdrant/storage
             name: qdrant
+        enableServiceLinks: false
+        securityContext:
+          fsGroup: 1000
         volumes:
         - name: qdrant
           persistentVolumeClaim:
@@ -4538,51 +3438,81 @@ items:
       targetPort: 6334
     selector:
       app: qdrant
+- apiVersion: v1
+  data:
+    launch.yaml: "\"processors\":\n- \"class\": \"trustgraph.agent.orchestrator.Processor\"\
+      \n  \"params\":\n    \"id\": \"agent-manager\"\n    \"pubsub_backend\": \"pulsar\"\
+      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.retrieval.graph_rag.Processor\"\
+      \n  \"params\":\n    \"concurrency\": 1\n    \"edge_limit\": 30\n    \"edge_score_limit\"\
+      : 10\n    \"entity_limit\": 50\n    \"id\": \"graph-rag\"\n    \"max_path_length\"\
+      : 2\n    \"max_subgraph_size\": 100\n    \"pubsub_backend\": \"pulsar\"\n  \
+      \  \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"triple_limit\": 30\n- \"\
+      class\": \"trustgraph.retrieval.document_rag.Processor\"\n  \"params\":\n  \
+      \  \"doc_limit\": 20\n    \"id\": \"document-rag\"\n    \"pubsub_backend\":\
+      \ \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"\
+      trustgraph.retrieval.nlp_query.Processor\"\n  \"params\":\n    \"id\": \"nlp-query\"\
+      \n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
+      \n- \"class\": \"trustgraph.retrieval.structured_query.Processor\"\n  \"params\"\
+      :\n    \"id\": \"structured-query\"\n    \"pubsub_backend\": \"pulsar\"\n  \
+      \  \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.retrieval.structured_diag.Processor\"\
+      \n  \"params\":\n    \"id\": \"structured-diag\"\n    \"pubsub_backend\": \"\
+      pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.query.sparql.Processor\"\
+      \n  \"params\":\n    \"id\": \"sparql-query\"\n    \"pubsub_backend\": \"pulsar\"\
+      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.prompt.template.Processor\"\
+      \n  \"params\":\n    \"concurrency\": 1\n    \"id\": \"prompt-rag\"\n    \"\
+      pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n\
+      - \"class\": \"trustgraph.agent.mcp_tool.Service\"\n  \"params\":\n    \"id\"\
+      : \"mcp-tool\"\n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"\
+      pulsar://pulsar:6650\""
+  kind: ConfigMap
+  metadata:
+    name: rag-launch-cfg
+    namespace: trustgraph
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
-      app: query-doc-embeddings
-    name: query-doc-embeddings
+      app: rag
+    name: rag
     namespace: trustgraph
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app: query-doc-embeddings
+        app: rag
     template:
       metadata:
         labels:
-          app: query-doc-embeddings
+          app: rag
       spec:
         containers:
         - command:
-          - doc-embeddings-query-qdrant
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - -t
-          - http://qdrant:6333
+          - processor-group
           - --log-level
           - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: query-doc-embeddings
+          - -c
+          - /etc/trustgraph/launch.yaml
+          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          name: rag
           resources:
             limits:
               cpu: '0.5'
-              memory: 128M
+              memory: 256M
             requests:
               cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
+              memory: 256M
+          volumeMounts:
+          - mountPath: /etc/trustgraph/
+            name: rag-launch-cfg
+        enableServiceLinks: false
+        volumes:
+        - configMap:
+            name: rag-launch-cfg
+          name: rag-launch-cfg
 - apiVersion: v1
   kind: Service
   metadata:
-    name: query-doc-embeddings
+    name: rag
     namespace: trustgraph
   spec:
     ports:
@@ -4590,143 +3520,45 @@ items:
       port: 8000
       targetPort: 8000
     selector:
-      app: query-doc-embeddings
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: query-graph-embeddings
-    name: query-graph-embeddings
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: query-graph-embeddings
-    template:
-      metadata:
-        labels:
-          app: query-graph-embeddings
-      spec:
-        containers:
-        - command:
-          - graph-embeddings-query-qdrant
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - -t
-          - http://qdrant:6333
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: query-graph-embeddings
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
+      app: rag
 - apiVersion: v1
-  kind: Service
+  data:
+    launch.yaml: "\"processors\":\n- \"class\": \"trustgraph.query.rows.cassandra.Processor\"\
+      \n  \"params\":\n    \"cassandra_host\": \"cassandra\"\n    \"id\": \"rows-query\"\
+      \n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
+      \n- \"class\": \"trustgraph.storage.rows.cassandra.Processor\"\n  \"params\"\
+      :\n    \"cassandra_host\": \"cassandra\"\n    \"id\": \"rows-write\"\n    \"\
+      pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\""
+  kind: ConfigMap
   metadata:
-    name: query-graph-embeddings
+    name: rows-launch-cfg
     namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: query-graph-embeddings
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
-      app: query-row-embeddings
-    name: query-row-embeddings
+      app: rows
+    name: rows
     namespace: trustgraph
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app: query-row-embeddings
+        app: rows
     template:
       metadata:
         labels:
-          app: query-row-embeddings
+          app: rows
       spec:
         containers:
         - command:
-          - row-embeddings-query-qdrant
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - -t
-          - http://qdrant:6333
+          - processor-group
           - --log-level
           - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: query-row-embeddings
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: query-row-embeddings
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: query-row-embeddings
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: query-rows
-    name: query-rows
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: query-rows
-    template:
-      metadata:
-        labels:
-          app: query-rows
-      spec:
-        containers:
-        - command:
-          - rows-query-cassandra
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --cassandra-host
-          - cassandra
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: query-rows
+          - -c
+          - /etc/trustgraph/launch.yaml
+          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          name: rows
           resources:
             limits:
               cpu: '0.5'
@@ -4734,14 +3566,18 @@ items:
             requests:
               cpu: '0.1'
               memory: 512M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
+          volumeMounts:
+          - mountPath: /etc/trustgraph/
+            name: rows-launch-cfg
+        enableServiceLinks: false
+        volumes:
+        - configMap:
+            name: rows-launch-cfg
+          name: rows-launch-cfg
 - apiVersion: v1
   kind: Service
   metadata:
-    name: query-rows
+    name: rows
     namespace: trustgraph
   spec:
     ports:
@@ -4749,529 +3585,21 @@ items:
       port: 8000
       targetPort: 8000
     selector:
-      app: query-rows
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: query-triples
-    name: query-triples
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: query-triples
-    template:
-      metadata:
-        labels:
-          app: query-triples
-      spec:
-        containers:
-        - command:
-          - triples-query-cassandra
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --cassandra-host
-          - cassandra
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: query-triples
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 512M
-            requests:
-              cpu: '0.1'
-              memory: 512M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
+      app: rows
 - apiVersion: v1
-  kind: Service
+  data:
+    launch.yaml: "\"processors\":\n- \"class\": \"trustgraph.model.text_completion.openai.Processor\"\
+      \n  \"params\":\n    \"concurrency\": 1\n    \"id\": \"text-completion\"\n \
+      \   \"max_output_tokens\": 4096\n    \"pubsub_backend\": \"pulsar\"\n    \"\
+      pulsar_host\": \"pulsar://pulsar:6650\"\n    \"temperature\": 0\n- \"class\"\
+      : \"trustgraph.model.text_completion.openai.Processor\"\n  \"params\":\n   \
+      \ \"concurrency\": 1\n    \"id\": \"text-completion-rag\"\n    \"max_output_tokens\"\
+      : 4096\n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
+      \n    \"temperature\": 0"
+  kind: ConfigMap
   metadata:
-    name: query-triples
+    name: text-completion-launch-cfg
     namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: query-triples
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: row-embeddings
-    name: row-embeddings
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: row-embeddings
-    template:
-      metadata:
-        labels:
-          app: row-embeddings
-      spec:
-        containers:
-        - command:
-          - row-embeddings
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: row-embeddings
-          resources:
-            limits:
-              cpu: '1.0'
-              memory: 256M
-            requests:
-              cpu: '0.5'
-              memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: row-embeddings
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: row-embeddings
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: sparql-query
-    name: sparql-query
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: sparql-query
-    template:
-      metadata:
-        labels:
-          app: sparql-query
-      spec:
-        containers:
-        - command:
-          - sparql-query
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: sparql-query
-          resources:
-            limits:
-              cpu: '1.0'
-              memory: 256M
-            requests:
-              cpu: '0.5'
-              memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: sparql-query
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: sparql-query
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: store-doc-embeddings
-    name: store-doc-embeddings
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: store-doc-embeddings
-    template:
-      metadata:
-        labels:
-          app: store-doc-embeddings
-      spec:
-        containers:
-        - command:
-          - doc-embeddings-write-qdrant
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - -t
-          - http://qdrant:6333
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: store-doc-embeddings
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 256M
-            requests:
-              cpu: '0.1'
-              memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: store-doc-embeddings
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: store-doc-embeddings
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: store-graph-embeddings
-    name: store-graph-embeddings
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: store-graph-embeddings
-    template:
-      metadata:
-        labels:
-          app: store-graph-embeddings
-      spec:
-        containers:
-        - command:
-          - graph-embeddings-write-qdrant
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - -t
-          - http://qdrant:6333
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: store-graph-embeddings
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: store-graph-embeddings
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: store-graph-embeddings
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: store-row-embeddings
-    name: store-row-embeddings
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: store-row-embeddings
-    template:
-      metadata:
-        labels:
-          app: store-row-embeddings
-      spec:
-        containers:
-        - command:
-          - row-embeddings-write-qdrant
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - -t
-          - http://qdrant:6333
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: store-row-embeddings
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: store-row-embeddings
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: store-row-embeddings
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: store-rows
-    name: store-rows
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: store-rows
-    template:
-      metadata:
-        labels:
-          app: store-rows
-      spec:
-        containers:
-        - command:
-          - rows-write-cassandra
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --cassandra-host
-          - cassandra
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: store-rows
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: store-rows
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: store-rows
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: store-triples
-    name: store-triples
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: store-triples
-    template:
-      metadata:
-        labels:
-          app: store-triples
-      spec:
-        containers:
-        - command:
-          - triples-write-cassandra
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --cassandra-host
-          - cassandra
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: store-triples
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 256M
-            requests:
-              cpu: '0.1'
-              memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: store-triples
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: store-triples
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: structured-diag
-    name: structured-diag
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: structured-diag
-    template:
-      metadata:
-        labels:
-          app: structured-diag
-      spec:
-        containers:
-        - command:
-          - structured-diag
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: structured-diag
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 96M
-            requests:
-              cpu: '0.1'
-              memory: 96M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: structured-diag
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: structured-diag
-- apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    labels:
-      app: structured-query
-    name: structured-query
-    namespace: trustgraph
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
-        app: structured-query
-    template:
-      metadata:
-        labels:
-          app: structured-query
-      spec:
-        containers:
-        - command:
-          - structured-query
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --log-level
-          - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: structured-query
-          resources:
-            limits:
-              cpu: '0.5'
-              memory: 128M
-            requests:
-              cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
-- apiVersion: v1
-  kind: Service
-  metadata:
-    name: structured-query
-    namespace: trustgraph
-  spec:
-    ports:
-    - name: metrics
-      port: 8000
-      targetPort: 8000
-    selector:
-      app: structured-query
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -5291,17 +3619,11 @@ items:
       spec:
         containers:
         - command:
-          - text-completion-openai
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - -x
-          - '4096'
-          - -t
-          - '0.000'
+          - processor-group
           - --log-level
           - INFO
+          - -c
+          - /etc/trustgraph/launch.yaml
           env:
           - name: OPENAI_TOKEN
             valueFrom:
@@ -5313,7 +3635,7 @@ items:
               secretKeyRef:
                 key: openai-url
                 name: openai-credentials
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
+          image: docker.io/trustgraph/trustgraph-flow:2.4.29
           name: text-completion
           resources:
             limits:
@@ -5322,10 +3644,14 @@ items:
             requests:
               cpu: '0.1'
               memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
+          volumeMounts:
+          - mountPath: /etc/trustgraph/
+            name: text-completion-launch-cfg
+        enableServiceLinks: false
+        volumes:
+        - configMap:
+            name: text-completion-launch-cfg
+          name: text-completion-launch-cfg
 - apiVersion: v1
   kind: Service
   metadata:
@@ -5338,66 +3664,63 @@ items:
       targetPort: 8000
     selector:
       app: text-completion
+- apiVersion: v1
+  data:
+    launch.yaml: "\"processors\":\n- \"class\": \"trustgraph.query.triples.cassandra.Processor\"\
+      \n  \"params\":\n    \"cassandra_host\": \"cassandra\"\n    \"id\": \"triples-query\"\
+      \n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
+      \n- \"class\": \"trustgraph.storage.triples.cassandra.Processor\"\n  \"params\"\
+      :\n    \"cassandra_host\": \"cassandra\"\n    \"id\": \"triples-write\"\n  \
+      \  \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\""
+  kind: ConfigMap
+  metadata:
+    name: triples-launch-cfg
+    namespace: trustgraph
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
-      app: text-completion-rag
-    name: text-completion-rag
+      app: triples
+    name: triples
     namespace: trustgraph
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app: text-completion-rag
+        app: triples
     template:
       metadata:
         labels:
-          app: text-completion-rag
+          app: triples
       spec:
         containers:
         - command:
-          - text-completion-openai
-          - --pubsub-backend
-          - pulsar
-          - --pulsar-host
-          - pulsar://pulsar:6650
-          - --id
-          - text-completion-rag
-          - -x
-          - '4096'
-          - -t
-          - '0.000'
+          - processor-group
           - --log-level
           - INFO
-          env:
-          - name: OPENAI_TOKEN
-            valueFrom:
-              secretKeyRef:
-                key: openai-token
-                name: openai-credentials
-          - name: OPENAI_BASE_URL
-            valueFrom:
-              secretKeyRef:
-                key: openai-url
-                name: openai-credentials
-          image: docker.io/trustgraph/trustgraph-flow:2.2.24
-          name: text-completion-rag
+          - -c
+          - /etc/trustgraph/launch.yaml
+          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          name: triples
           resources:
             limits:
               cpu: '0.5'
-              memory: 128M
+              memory: 512M
             requests:
               cpu: '0.1'
-              memory: 128M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
-        volumes: []
+              memory: 512M
+          volumeMounts:
+          - mountPath: /etc/trustgraph/
+            name: triples-launch-cfg
+        enableServiceLinks: false
+        volumes:
+        - configMap:
+            name: triples-launch-cfg
+          name: triples-launch-cfg
 - apiVersion: v1
   kind: Service
   metadata:
-    name: text-completion-rag
+    name: triples
     namespace: trustgraph
   spec:
     ports:
@@ -5405,27 +3728,27 @@ items:
       port: 8000
       targetPort: 8000
     selector:
-      app: text-completion-rag
+      app: triples
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
     labels:
-      app: workbench-ui
-    name: workbench-ui
+      app: trustgraph-ui
+    name: trustgraph-ui
     namespace: trustgraph
   spec:
     replicas: 1
     selector:
       matchLabels:
-        app: workbench-ui
+        app: trustgraph-ui
     template:
       metadata:
         labels:
-          app: workbench-ui
+          app: trustgraph-ui
       spec:
         containers:
-        - image: docker.io/trustgraph/workbench-ui:1.8.2
-          name: workbench-ui
+        - image: docker.io/trustgraph/trustgraph-ui:0.1.1
+          name: trustgraph-ui
           ports:
           - containerPort: 8888
             hostPort: 8888
@@ -5436,14 +3759,12 @@ items:
             requests:
               cpu: '0.1'
               memory: 256M
-          securityContext:
-            runAsGroup: 0
-            runAsUser: 0
+        enableServiceLinks: false
         volumes: []
 - apiVersion: v1
   kind: Service
   metadata:
-    name: workbench-ui
+    name: trustgraph-ui
     namespace: trustgraph
   spec:
     ports:
@@ -5451,6 +3772,84 @@ items:
       port: 8888
       targetPort: 8888
     selector:
-      app: workbench-ui
+      app: trustgraph-ui
+- apiVersion: v1
+  data:
+    launch.yaml: "\"processors\":\n- \"class\": \"trustgraph.query.doc_embeddings.qdrant.Processor\"\
+      \n  \"params\":\n    \"id\": \"doc-embeddings-query\"\n    \"pubsub_backend\"\
+      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
+      : \"http://qdrant:6333\"\n- \"class\": \"trustgraph.storage.doc_embeddings.qdrant.Processor\"\
+      \n  \"params\":\n    \"id\": \"doc-embeddings-write\"\n    \"pubsub_backend\"\
+      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
+      : \"http://qdrant:6333\"\n- \"class\": \"trustgraph.query.graph_embeddings.qdrant.Processor\"\
+      \n  \"params\":\n    \"id\": \"graph-embeddings-query\"\n    \"pubsub_backend\"\
+      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
+      : \"http://qdrant:6333\"\n- \"class\": \"trustgraph.storage.graph_embeddings.qdrant.Processor\"\
+      \n  \"params\":\n    \"id\": \"graph-embeddings-write\"\n    \"pubsub_backend\"\
+      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
+      : \"http://qdrant:6333\"\n- \"class\": \"trustgraph.query.row_embeddings.qdrant.Processor\"\
+      \n  \"params\":\n    \"id\": \"row-embeddings-query\"\n    \"pubsub_backend\"\
+      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
+      : \"http://qdrant:6333\"\n- \"class\": \"trustgraph.storage.row_embeddings.qdrant.Processor\"\
+      \n  \"params\":\n    \"id\": \"row-embeddings-write\"\n    \"pubsub_backend\"\
+      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
+      : \"http://qdrant:6333\""
+  kind: ConfigMap
+  metadata:
+    name: vector-store-cfg
+    namespace: trustgraph
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: vector-store
+    name: vector-store
+    namespace: trustgraph
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: vector-store
+    template:
+      metadata:
+        labels:
+          app: vector-store
+      spec:
+        containers:
+        - command:
+          - processor-group
+          - --log-level
+          - INFO
+          - -c
+          - /etc/trustgraph/launch.yaml
+          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          name: vector-store
+          resources:
+            limits:
+              cpu: '0.5'
+              memory: 256M
+            requests:
+              cpu: '0.1'
+              memory: 256M
+          volumeMounts:
+          - mountPath: /etc/trustgraph/
+            name: vector-store-cfg
+        enableServiceLinks: false
+        volumes:
+        - configMap:
+            name: vector-store-cfg
+          name: vector-store-cfg
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: vector-store
+    namespace: trustgraph
+  spec:
+    ports:
+    - name: metrics
+      port: 8000
+      targetPort: 8000
+    selector:
+      app: vector-store
 kind: List
 


### PR DESCRIPTION
## Summary
- Upgrade TrustGraph from 2.2.24 to 2.4.29 (regenerated resources.yaml)
- Add Pulumi-managed random passwords for IAM bootstrap token and Grafana admin password
- Export both as stack outputs (`iamToken`, `grafanaPassword`) retrievable with `--show-secrets`
- Remove obsolete gateway-secret and mcp-server-secret (no longer used in 2.4.29 templates)
- Update README with secret retrieval instructions

## Test plan
- [ ] Run `pulumi preview` to verify no errors in the new resource definitions
- [ ] Deploy with `pulumi up` and confirm `iam-bootstrap-token` and `grafana-secret` K8s secrets are created
- [ ] Verify `pulumi stack output iamToken --show-secrets` returns a `tg_`-prefixed token
- [ ] Verify `pulumi stack output grafanaPassword --show-secrets` returns a password
- [ ] Confirm Grafana login works with `admin` / generated password
- [ ] Confirm API gateway authentication works with the generated token
