### PR TITLE
Add HTTPS gateway with Nginx Gateway Fabric and Let's Encrypt

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,12 @@ platform.
 The full stack includes:
 
 - A Kubernetes cluster
-- Node pool containing 2 nodes
+- Node pool containing 4 nodes
 - An IAM application plus policy granting Gen AI access
-- Deploys a complete TrustGraph stack of resources in AKS
+- Deploys a complete TrustGraph stack of resources in Kubernetes
+- Nginx Gateway Fabric for ingress with Gateway API
+- cert-manager with Let's Encrypt TLS certificates
+- HTTPS access to TrustGraph UI and Grafana via public DNS names
 
 Keys and other configuration for the AI components are configured into
 TrustGraph using secrets.
@@ -108,6 +111,12 @@ The `Pulumi.STACKNAME.yaml` configuration file contains settings for:
 - `trustgraph-scaleway:region` - Scaleway deployment location (e.g. fr-par).
 - `trustgraph-scaleway:environment` - Name of the environment you are deploying
   use a name like: dev, prod etc.
+- `trustgraph-scaleway:domain` - Domain name for the TrustGraph UI
+  (e.g. app.example.com).
+- `trustgraph-scaleway:grafana-domain` - Domain name for Grafana
+  (e.g. grafana.example.com).
+- `trustgraph-scaleway:letsencrypt-email` - Email address for Let's Encrypt
+  certificate registration.
 
 ## Deploy
 
@@ -131,19 +140,34 @@ If something goes wrong while deploying, retry before giving up.
 `pulumi up` is a retryable command and will continue from
 where it left off.
 
+## DNS setup
+
+After deployment, get the LoadBalancer IP assigned to the gateway:
+
+```
+kubectl --kubeconfig kube.cfg -n nginx-gateway get svc
+```
+
+Create DNS A records pointing both your domain and grafana-domain at this
+IP address.  cert-manager will automatically obtain Let's Encrypt TLS
+certificates once DNS resolves.
+
 ## Use the system
 
-To get access to TrustGraph using the `kube.cfg` file, set up some
-port-forwarding.  You'll need multiple terminal windows to run each of
-these commands:
+Once DNS is configured, access the services at:
+
+- TrustGraph UI: `https://<your-domain>`
+- Grafana: `https://<your-grafana-domain>`
+
+Alternatively, you can use port-forwarding with the `kube.cfg` file:
 
 ```
 kubectl --kubeconfig kube.cfg -n trustgraph port-forward service/api-gateway 8088:8088
-kubectl --kubeconfig kube.cfg -n trustgraph port-forward service/workbench-ui 8888:8888
+kubectl --kubeconfig kube.cfg -n trustgraph port-forward service/trustgraph-ui 8888:8888
 kubectl --kubeconfig kube.cfg -n trustgraph port-forward service/grafana 3000:3000
 ```
 
-This will allow you to access Grafana and the Workbench UI from your local
+This will allow you to access Grafana and the TrustGraph UI from your local
 browser using `http://localhost:3000` and `http://localhost:8888`
 respectively.
 
@@ -163,7 +187,7 @@ export TRUSTGRAPH_TOKEN=$(pulumi stack output iamToken --show-secrets)
 ```
 
 
-## Deploy
+## Destroy
 
 ```
 pulumi destroy
@@ -180,5 +204,5 @@ The AI model specified in the config.json should match the model in the
 AI endpoint hostname specified in the Pulumi config.
 
 ```
-./update-config scw-k8s 2.4.29
+./update-config scw-k8s 2.5.16
 ```

--- a/config.json
+++ b/config.json
@@ -4,11 +4,19 @@
         "parameters": {}
     },
     {
+        "name": "vector-store-qdrant",
+        "parameters": {}
+    },
+    {
         "name": "row-store-cassandra",
         "parameters": {}
     },
     {
-        "name": "vector-store-qdrant",
+        "name": "cassandra",
+        "parameters": {}
+    },
+    {
+        "name": "garage",
         "parameters": {}
     },
     {
@@ -21,6 +29,10 @@
     },
     {
         "name": "trustgraph-base",
+        "parameters": {}
+    },
+    {
+        "name": "mcp-server",
         "parameters": {}
     },
     {
@@ -39,7 +51,7 @@
 		    {
 			id: "mistral-small-3.2-24b-instruct-2506",
 			description: "Mistral small 3.2 24b instruct (2506)"
-		    },
+		    }
 		],
 		"required": true
 	    }

--- a/pulumi/Pulumi.scaleway.yaml.EXAMPLE
+++ b/pulumi/Pulumi.scaleway.yaml.EXAMPLE
@@ -2,3 +2,6 @@ encryptionsalt: v1:G0sdswyspGE=:v1:qvr//j1wOQ/TNYdn:+RDSqqZc8RK/NTKkMh0paajyuXmS
 config:
   trustgraph-scaleway:environment: dev
   trustgraph-scaleway:region: fr-par
+  trustgraph-scaleway:domain: app.example.com
+  trustgraph-scaleway:grafana-domain: grafana.example.com
+  trustgraph-scaleway:letsencrypt-email: admin@example.com

--- a/pulumi/__tests__/config.test.ts
+++ b/pulumi/__tests__/config.test.ts
@@ -17,6 +17,9 @@ describe("Configuration Loading", () => {
         pulumi.runtime.setAllConfig({
             "project:environment": "test",
             "project:region": "fr-par",
+            "project:domain": "app.example.com",
+            "project:grafana-domain": "grafana.example.com",
+            "project:letsencrypt-email": "test@example.com",
         });
     });
 
@@ -44,9 +47,20 @@ describe("Configuration Loading", () => {
         expect(config.nodeCount).toBe(4);
     });
 
+    test("should load gateway configuration values", async () => {
+        const config = await import("../config");
+
+        expect(config.domain).toBe("app.example.com");
+        expect(config.grafanaDomain).toBe("grafana.example.com");
+        expect(config.letsencryptEmail).toBe("test@example.com");
+    });
+
     test("should handle missing environment configuration", async () => {
         pulumi.runtime.setAllConfig({
             "project:region": "fr-par",
+            "project:domain": "app.example.com",
+            "project:grafana-domain": "grafana.example.com",
+            "project:letsencrypt-email": "test@example.com",
         });
 
         await expect(import("../config")).rejects.toThrow();
@@ -55,6 +69,42 @@ describe("Configuration Loading", () => {
     test("should handle missing region configuration", async () => {
         pulumi.runtime.setAllConfig({
             "project:environment": "test",
+            "project:domain": "app.example.com",
+            "project:grafana-domain": "grafana.example.com",
+            "project:letsencrypt-email": "test@example.com",
+        });
+
+        await expect(import("../config")).rejects.toThrow();
+    });
+
+    test("should handle missing domain configuration", async () => {
+        pulumi.runtime.setAllConfig({
+            "project:environment": "test",
+            "project:region": "fr-par",
+            "project:grafana-domain": "grafana.example.com",
+            "project:letsencrypt-email": "test@example.com",
+        });
+
+        await expect(import("../config")).rejects.toThrow();
+    });
+
+    test("should handle missing grafana-domain configuration", async () => {
+        pulumi.runtime.setAllConfig({
+            "project:environment": "test",
+            "project:region": "fr-par",
+            "project:domain": "app.example.com",
+            "project:letsencrypt-email": "test@example.com",
+        });
+
+        await expect(import("../config")).rejects.toThrow();
+    });
+
+    test("should handle missing letsencrypt-email configuration", async () => {
+        pulumi.runtime.setAllConfig({
+            "project:environment": "test",
+            "project:region": "fr-par",
+            "project:domain": "app.example.com",
+            "project:grafana-domain": "grafana.example.com",
         });
 
         await expect(import("../config")).rejects.toThrow();

--- a/pulumi/__tests__/infrastructure.test.ts
+++ b/pulumi/__tests__/infrastructure.test.ts
@@ -12,6 +12,9 @@ let resourceCount = 0;
 describe("Infrastructure Creation", () => {
     beforeAll(() => {
         // Mock file system
+        mockedFs.writeFile.mockImplementation(
+            (_path: any, _data: any, cb: any) => cb?.(null)
+        );
         mockedFs.readFileSync.mockReturnValue(`
 apiVersion: v1
 kind: Namespace
@@ -30,8 +33,11 @@ spec:
         // Set up configuration
         pulumi.runtime.setAllConfig({
             "project:environment": "test",
-            "project:region": "fr-par", 
+            "project:region": "fr-par",
             "project:ai-model": "llama-3.1-8b-instruct",
+            "project:domain": "app.example.com",
+            "project:grafana-domain": "grafana.example.com",
+            "project:letsencrypt-email": "test@example.com",
         });
         
         // Set up mocks to capture resource creation
@@ -62,6 +68,10 @@ spec:
                 
                 if (args.type === "scaleway:iam/apiKey:ApiKey") {
                     state.secretKey = "mock-secret-key-value";
+                }
+
+                if (args.type === "kubernetes:core/v1:Service") {
+                    state.status = { loadBalancer: { ingress: [{ ip: "1.2.3.4" }] } };
                 }
                 
                 return { id: mockId, state };
@@ -134,6 +144,65 @@ spec:
         expect(grafanaSecret?.inputs.metadata?.namespace).toBe("trustgraph");
         expect(aiSecret?.inputs.metadata?.namespace).toBe("trustgraph");
         
-        // console.log(`Created ${createdResources.length} resources:`, createdResources.map(r => r.type));
+        // Check for cert-manager resources
+        const certManagerNs = createdResources.find(
+            r => r.type === "kubernetes:core/v1:Namespace" && r.inputs.metadata?.name === "cert-manager"
+        );
+        expect(certManagerNs).toBeDefined();
+
+        const certManagerChart = createdResources.find(
+            r => r.name === "cert-manager"
+                && r.type === "kubernetes:helm.sh/v4:Chart"
+        );
+        expect(certManagerChart).toBeDefined();
+
+        const clusterIssuer = createdResources.find(
+            r => r.type === "kubernetes:cert-manager.io/v1:ClusterIssuer"
+        );
+        expect(clusterIssuer).toBeDefined();
+
+        // Check for Nginx Gateway Fabric resources
+        const ngfNs = createdResources.find(
+            r => r.type === "kubernetes:core/v1:Namespace" && r.inputs.metadata?.name === "nginx-gateway"
+        );
+        expect(ngfNs).toBeDefined();
+
+        const ngfChart = createdResources.find(
+            r => r.name === "nginx-gateway-fabric"
+                && r.type === "kubernetes:helm.sh/v4:Chart"
+        );
+        expect(ngfChart).toBeDefined();
+
+        // Check for Gateway
+        const gw = createdResources.find(
+            r => r.type === "kubernetes:gateway.networking.k8s.io/v1:Gateway"
+        );
+        expect(gw).toBeDefined();
+        expect(gw?.inputs.spec?.gatewayClassName).toBe("nginx");
+        expect(gw?.inputs.spec?.listeners).toHaveLength(3);
+
+        // Check for Certificates
+        const uiCert = createdResources.find(
+            r => r.type === "kubernetes:cert-manager.io/v1:Certificate"
+                && r.name === "ui-cert"
+        );
+        const grafanaCert = createdResources.find(
+            r => r.type === "kubernetes:cert-manager.io/v1:Certificate"
+                && r.name === "grafana-cert"
+        );
+        expect(uiCert).toBeDefined();
+        expect(grafanaCert).toBeDefined();
+
+        // Check for HTTPRoutes
+        const uiRoute = createdResources.find(
+            r => r.type === "kubernetes:gateway.networking.k8s.io/v1:HTTPRoute"
+                && r.name === "ui-route"
+        );
+        const grafanaRoute = createdResources.find(
+            r => r.type === "kubernetes:gateway.networking.k8s.io/v1:HTTPRoute"
+                && r.name === "grafana-route"
+        );
+        expect(uiRoute).toBeDefined();
+        expect(grafanaRoute).toBeDefined();
     });
 });

--- a/pulumi/application.ts
+++ b/pulumi/application.ts
@@ -1,0 +1,18 @@
+
+import * as k8s from '@pulumi/kubernetes';
+import * as fs from 'fs';
+
+import { k8sProvider } from './cluster';
+
+// Get application resource definitions
+const resourceDefs = fs.readFileSync("../resources.yaml", {encoding: "utf-8"});
+
+// Deploy resources to the K8s cluster
+export const appDeploy = new k8s.yaml.v2.ConfigGroup(
+    "resources",
+    {
+        yaml: resourceDefs,
+        skipAwait: true,
+    },
+    { provider: k8sProvider }
+);

--- a/pulumi/cert-manager.ts
+++ b/pulumi/cert-manager.ts
@@ -1,0 +1,57 @@
+
+import * as k8s from '@pulumi/kubernetes';
+
+import { k8sProvider } from './cluster';
+import { letsencryptEmail } from './config';
+
+const certManagerNamespace = new k8s.core.v1.Namespace(
+    "cert-manager",
+    {
+        metadata: { name: "cert-manager" },
+    },
+    { provider: k8sProvider }
+);
+
+export const certManager = new k8s.helm.v4.Chart(
+    "cert-manager",
+    {
+        chart: "oci://quay.io/jetstack/charts/cert-manager",
+        version: "v1.17.2",
+        namespace: "cert-manager",
+        values: {
+            crds: { enabled: true },
+            config: { enableGatewayAPI: true },
+        },
+    },
+    { provider: k8sProvider, dependsOn: [certManagerNamespace] }
+);
+
+export const letsEncryptIssuer = new k8s.apiextensions.CustomResource(
+    "letsencrypt-issuer",
+    {
+        apiVersion: "cert-manager.io/v1",
+        kind: "ClusterIssuer",
+        metadata: { name: "letsencrypt-prod" },
+        spec: {
+            acme: {
+                server: "https://acme-v02.api.letsencrypt.org/directory",
+                email: letsencryptEmail,
+                privateKeySecretRef: {
+                    name: "letsencrypt-private-key",
+                },
+                solvers: [{
+                    http01: {
+                        gatewayHTTPRoute: {
+                            parentRefs: [{
+                                name: "trustgraph-gateway",
+                                namespace: "trustgraph",
+                                kind: "Gateway",
+                            }],
+                        },
+                    },
+                }],
+            },
+        },
+    },
+    { provider: k8sProvider, dependsOn: [certManager] }
+);

--- a/pulumi/cluster.ts
+++ b/pulumi/cluster.ts
@@ -1,0 +1,95 @@
+
+import * as scaleway from '@pulumiverse/scaleway';
+import * as pulumi from '@pulumi/pulumi';
+import * as k8s from '@pulumi/kubernetes';
+import * as fs from 'fs';
+
+import { prefix, region, nodeSize, nodeCount } from './config';
+
+// Scaleway provider, allows setting the default region
+export const provider = new scaleway.Provider(
+    "scaleway-provider",
+    {
+        region: region
+    }
+);
+
+// Get project information
+export const project = scaleway.account.getProjectOutput(
+    {},
+    { provider: provider }
+);
+
+// If you know the project ID, you can work out the Generative AI endpoint
+// URL
+export const aiUrl = project.id.apply(
+    proj => `https://api.scaleway.ai/${proj}/v1`
+);
+
+// Create a private network
+const privateNetwork = new scaleway.network.PrivateNetwork(
+    "private-network",
+    {
+        name: prefix,
+    },
+    { provider: provider }
+);
+
+// Create a K8s cluster
+const cluster = new scaleway.kubernetes.Cluster(
+    "cluster",
+    {
+        name: prefix + "-cluster",
+        version: "1.35.3",
+        cni: "cilium",
+        privateNetworkId: privateNetwork.id,
+        deleteAdditionalResources: false,
+    },
+    { provider: provider }
+);
+
+// Create a nodepool for the cluster
+export const nodePool = new scaleway.kubernetes.Pool(
+    "node-pool",
+    {
+        clusterId: cluster.id,
+        name: prefix + "-pool",
+        nodeType: nodeSize,
+        size: nodeCount,
+    },
+    { provider: provider }
+);
+
+// Get the kubeconfig for the cluster.  This has to depend on the node pool
+// being setup
+const kubeconfig = pulumi.all([
+    cluster.kubeconfigs, nodePool.id
+]).apply(
+    ([kconf, node]) => kconf[0].configFile
+);
+
+// Create a Kubernetes provider using the cluster's kubeconfig
+export const k8sProvider = new k8s.Provider(
+    "k8sProvider",
+    {
+        kubeconfig: kubeconfig,
+    }
+);
+
+// Write the kubeconfig to a file
+kubeconfig.apply(
+    (key : string) => {
+        fs.writeFile(
+            "kube.cfg",
+            key,
+            err => {
+                if (err) {
+                    console.log(err);
+                    throw(err);
+                } else {
+                    console.log("Wrote kube.cfg.");
+                }
+            }
+        );
+    }
+);

--- a/pulumi/config.ts
+++ b/pulumi/config.ts
@@ -25,3 +25,7 @@ export const prefix = "trustgraph-" + environment;
 // TrustGraph version
 export const nodeSize = "DEV1-L";
 export const nodeCount = 4;
+
+export const domain = cfg.require("domain");
+export const grafanaDomain = cfg.require("grafana-domain");
+export const letsencryptEmail = cfg.require("letsencrypt-email");

--- a/pulumi/gateway.ts
+++ b/pulumi/gateway.ts
@@ -1,0 +1,206 @@
+
+import * as pulumi from '@pulumi/pulumi';
+import * as k8s from '@pulumi/kubernetes';
+
+import { k8sProvider } from './cluster';
+import { domain, grafanaDomain } from './config';
+import { letsEncryptIssuer } from './cert-manager';
+import { appDeploy } from './application';
+
+// ---------- Nginx Gateway Fabric ----------
+
+const ngfNamespace = new k8s.core.v1.Namespace(
+    "nginx-gateway",
+    {
+        metadata: { name: "nginx-gateway" },
+    },
+    { provider: k8sProvider }
+);
+
+const nginxGatewayFabric = new k8s.helm.v4.Chart(
+    "nginx-gateway-fabric",
+    {
+        chart: "oci://ghcr.io/nginx/charts/nginx-gateway-fabric",
+        version: "1.6.2",
+        namespace: "nginx-gateway",
+        values: {
+            nginxGateway: {
+                gatewayClassName: "nginx",
+            },
+        },
+    },
+    { provider: k8sProvider, dependsOn: [ngfNamespace] }
+);
+
+const ngfServiceId = nginxGatewayFabric.resources.apply(
+    () => "nginx-gateway/nginx-gateway-fabric"
+);
+
+const ngfService = k8s.core.v1.Service.get("ngf-service", ngfServiceId,
+    { provider: k8sProvider });
+
+export const gatewayIp = ngfService.status.apply(
+    s => s?.loadBalancer?.ingress?.[0]?.ip || s?.loadBalancer?.ingress?.[0]?.hostname || "pending"
+);
+
+// ---------- Gateway + TLS + Routes ----------
+
+const gateway = new k8s.apiextensions.CustomResource(
+    "trustgraph-gateway",
+    {
+        apiVersion: "gateway.networking.k8s.io/v1",
+        kind: "Gateway",
+        metadata: {
+            name: "trustgraph-gateway",
+            namespace: "trustgraph",
+        },
+        spec: {
+            gatewayClassName: "nginx",
+            listeners: [
+                {
+                    name: "http",
+                    protocol: "HTTP",
+                    port: 80,
+                    allowedRoutes: {
+                        namespaces: { from: "Same" },
+                    },
+                },
+                {
+                    name: "https-ui",
+                    protocol: "HTTPS",
+                    port: 443,
+                    hostname: domain,
+                    tls: {
+                        certificateRefs: [{
+                            name: "ui-tls",
+                        }],
+                    },
+                    allowedRoutes: {
+                        namespaces: { from: "Same" },
+                    },
+                },
+                {
+                    name: "https-grafana",
+                    protocol: "HTTPS",
+                    port: 443,
+                    hostname: grafanaDomain,
+                    tls: {
+                        certificateRefs: [{
+                            name: "grafana-tls",
+                        }],
+                    },
+                    allowedRoutes: {
+                        namespaces: { from: "Same" },
+                    },
+                },
+            ],
+        },
+    },
+    { provider: k8sProvider, dependsOn: [nginxGatewayFabric, appDeploy] }
+);
+
+const uiCertificate = new k8s.apiextensions.CustomResource(
+    "ui-cert",
+    {
+        apiVersion: "cert-manager.io/v1",
+        kind: "Certificate",
+        metadata: {
+            name: "ui-cert",
+            namespace: "trustgraph",
+        },
+        spec: {
+            secretName: "ui-tls",
+            issuerRef: {
+                name: "letsencrypt-prod",
+                kind: "ClusterIssuer",
+            },
+            dnsNames: [domain],
+        },
+    },
+    { provider: k8sProvider, dependsOn: [letsEncryptIssuer, gateway] }
+);
+
+const grafanaCertificate = new k8s.apiextensions.CustomResource(
+    "grafana-cert",
+    {
+        apiVersion: "cert-manager.io/v1",
+        kind: "Certificate",
+        metadata: {
+            name: "grafana-cert",
+            namespace: "trustgraph",
+        },
+        spec: {
+            secretName: "grafana-tls",
+            issuerRef: {
+                name: "letsencrypt-prod",
+                kind: "ClusterIssuer",
+            },
+            dnsNames: [grafanaDomain],
+        },
+    },
+    { provider: k8sProvider, dependsOn: [letsEncryptIssuer, gateway] }
+);
+
+const uiRoute = new k8s.apiextensions.CustomResource(
+    "ui-route",
+    {
+        apiVersion: "gateway.networking.k8s.io/v1",
+        kind: "HTTPRoute",
+        metadata: {
+            name: "ui-route",
+            namespace: "trustgraph",
+        },
+        spec: {
+            parentRefs: [
+                {
+                    name: "trustgraph-gateway",
+                    sectionName: "https-ui",
+                },
+                {
+                    name: "trustgraph-gateway",
+                    sectionName: "http",
+                },
+            ],
+            hostnames: [domain],
+            rules: [{
+                backendRefs: [{
+                    name: "trustgraph-ui",
+                    port: 8888,
+                }],
+            }],
+        },
+    },
+    { provider: k8sProvider, dependsOn: [gateway] }
+);
+
+const grafanaRoute = new k8s.apiextensions.CustomResource(
+    "grafana-route",
+    {
+        apiVersion: "gateway.networking.k8s.io/v1",
+        kind: "HTTPRoute",
+        metadata: {
+            name: "grafana-route",
+            namespace: "trustgraph",
+        },
+        spec: {
+            parentRefs: [
+                {
+                    name: "trustgraph-gateway",
+                    sectionName: "https-grafana",
+                },
+                {
+                    name: "trustgraph-gateway",
+                    sectionName: "http",
+                },
+            ],
+            hostnames: [grafanaDomain],
+            rules: [{
+                backendRefs: [{
+                    name: "grafana",
+                    port: 3000,
+                }],
+            }],
+        },
+    },
+    { provider: k8sProvider, dependsOn: [gateway] }
+);

--- a/pulumi/index.ts
+++ b/pulumi/index.ts
@@ -1,11 +1,13 @@
 
-import * as scaleway from '@pulumiverse/scaleway';
 import * as pulumi from '@pulumi/pulumi';
 import * as k8s from '@pulumi/kubernetes';
 import * as random from '@pulumi/random';
-import * as fs from 'fs';
+import * as scaleway from '@pulumiverse/scaleway';
 
-import { prefix, region, nodeSize, nodeCount } from './config';
+import { provider, project, aiUrl, nodePool, k8sProvider } from './cluster';
+import { appDeploy } from './application';
+
+import { gatewayIp } from './gateway';
 
 const iamBootstrapToken = new random.RandomPassword(
     "iam-bootstrap-token",
@@ -22,76 +24,6 @@ const grafanaAdminPassword = new random.RandomPassword(
         special: true,
         overrideSpecial: "!@#$%^&*",
     },
-);
-
-// Scaleway provider, allows setting the default region
-const provider = new scaleway.Provider(
-    "scaleway-provider",
-    {
-        region: region
-    }
-);
-
-// Get project information
-const project = scaleway.account.getProjectOutput(
-    {},
-    { provider: provider }
-);
-
-// If you know the project ID, you can work out the Generative AI endpoint
-// URL
-const aiUrl = project.id.apply(
-    proj => `https://api.scaleway.ai/${proj}/v1`
-);
-
-// Create a private network
-const privateNetwork = new scaleway.network.PrivateNetwork(
-    "private-network",
-    {
-        name: prefix,
-    },
-    { provider: provider }
-);
-
-// Create a K8s cluster
-const cluster = new scaleway.kubernetes.Cluster(
-    "cluster",
-    {
-        name: prefix + "-cluster",
-        version: "1.35.3",
-        cni: "cilium",
-        privateNetworkId: privateNetwork.id,
-        deleteAdditionalResources: false,
-    },
-    { provider: provider }
-);
-
-// Create a nodepool for the cluster
-const nodePool = new scaleway.kubernetes.Pool(
-    "node-pool",
-    {
-        clusterId: cluster.id,
-        name: prefix + "-pool",
-        nodeType: nodeSize,
-        size: nodeCount,
-    },
-    { provider: provider }
-);
-
-// Get the kubeconfig for the cluster.  This has to depend on the node pool
-// being setup
-const kubeconfig = pulumi.all([
-    cluster.kubeconfigs, nodePool.id
-]).apply(
-    ([kconf, node]) => kconf[0].configFile
-);
-
-// Create a Kubernetes provider using the cluster's kubeconfig
-const k8sProvider = new k8s.Provider(
-    "k8sProvider",
-    {
-        kubeconfig: kubeconfig,
-    }
 );
 
 // Create an IAM application
@@ -126,37 +58,6 @@ const apiKey = new scaleway.iam.ApiKey(
         description: "TrustGraph AI key",
     },
     { provider: provider }
-);
-
-// Write the kubeconfig to a file
-kubeconfig.apply(
-    (key : string) => {
-        fs.writeFile(
-            "kube.cfg",
-            key,
-            err => {
-                if (err) {
-                    console.log(err);
-                    throw(err);
-                } else {
-                    console.log("Wrote kube.cfg.");
-                }
-            }
-        );
-    }
-);
-
-// Get application resource definitions
-const resourceDefs = fs.readFileSync("../resources.yaml", {encoding: "utf-8"});
-
-// Deploy resources to the K8s cluster
-const appDeploy = new k8s.yaml.v2.ConfigGroup(
-    "resources",
-    {
-        yaml: resourceDefs,
-        skipAwait: true,
-    },
-    { provider: k8sProvider }
 );
 
 const iamSecret = new k8s.core.v1.Secret(
@@ -207,3 +108,4 @@ export const iamToken = pulumi.interpolate`tg_${iamBootstrapToken.result}`;
 
 export const grafanaPassword = grafanaAdminPassword.result;
 
+export { gatewayIp };

--- a/resources.yaml
+++ b/resources.yaml
@@ -54,7 +54,7 @@ items:
           - '8088'
           - --log-level
           - INFO
-          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          image: docker.io/trustgraph/trustgraph-flow:2.5.16
           name: api-gateway
           ports:
           - containerPort: 8088
@@ -78,6 +78,15 @@ items:
     - name: api
       port: 8088
       targetPort: 8088
+    selector:
+      app: api-gateway
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: api-gateway-metrics
+    namespace: trustgraph
+  spec:
+    ports:
     - name: metrics
       port: 8000
       targetPort: 8000
@@ -115,7 +124,7 @@ items:
         containers:
         - env:
           - name: JVM_OPTS
-            value: -Xms300M -Xmx300M -Dcassandra.skip_wait_for_gossip_to_settle=0
+            value: -Xms500M -Xmx500M -Dcassandra.skip_wait_for_gossip_to_settle=0
           image: docker.io/cassandra:5.0.8
           name: cassandra
           ports:
@@ -124,10 +133,10 @@ items:
           resources:
             limits:
               cpu: '1.0'
-              memory: 1000M
+              memory: 2000M
             requests:
               cpu: '0.5'
-              memory: 1000M
+              memory: 2000M
           volumeMounts:
           - mountPath: /var/lib/cassandra
             name: cassandra
@@ -153,31 +162,34 @@ items:
 - apiVersion: v1
   data:
     launch.yaml: "\"processors\":\n- \"class\": \"trustgraph.librarian.Processor\"\
-      \n  \"params\":\n    \"id\": \"librarian\"\n    \"object_store_access_key\"\
-      : \"GK000000000000000000000001\"\n    \"object_store_endpoint\": \"garage:3900\"\
-      \n    \"object_store_region\": \"garage\"\n    \"object_store_secret_key\":\
-      \ \"b171f00be9be4c32c734f4c05fe64c527a8ab5eb823b376cfa8c2531f70fc427\"\n   \
+      \n  \"params\":\n    \"cassandra_replication_factor\": 1\n    \"id\": \"librarian\"\
+      \n    \"object_store_access_key\": \"GK000000000000000000000001\"\n    \"object_store_endpoint\"\
+      : \"garage:3900\"\n    \"object_store_region\": \"garage\"\n    \"object_store_secret_key\"\
+      : \"b171f00be9be4c32c734f4c05fe64c527a8ab5eb823b376cfa8c2531f70fc427\"\n   \
       \ \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
       \n- \"class\": \"trustgraph.config.service.Processor\"\n  \"params\":\n    \"\
-      id\": \"config-svc\"\n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\"\
-      : \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.flow.service.Processor\"\
-      \n  \"params\":\n    \"id\": \"flow-svc\"\n    \"pubsub_backend\": \"pulsar\"\
-      \n    \"pulsar_admin_url\": \"http://pulsar:8080\"\n    \"pulsar_host\": \"\
-      pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.cores.service.Processor\"\n\
-      \  \"params\":\n    \"id\": \"knowledge\"\n    \"pubsub_backend\": \"pulsar\"\
-      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.storage.knowledge.store.Processor\"\
-      \n  \"params\":\n    \"id\": \"kg-store\"\n    \"pubsub_backend\": \"pulsar\"\
-      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.metering.Processor\"\
-      \n  \"params\":\n    \"id\": \"metering\"\n    \"pubsub_backend\": \"pulsar\"\
-      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.metering.Processor\"\
-      \n  \"params\":\n    \"id\": \"metering-rag\"\n    \"pubsub_backend\": \"pulsar\"\
-      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.iam.service.Processor\"\
-      \n  \"params\":\n    \"bootstrap_mode\": \"token\"\n    \"id\": \"iam-svc\"\n\
-      \    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
-      \n- \"class\": \"trustgraph.bootstrap.bootstrapper.Processor\"\n  \"params\"\
-      :\n    \"id\": \"bootstrap\"\n    \"initialisers\":\n    - \"class\": \"trustgraph.bootstrap.initialisers.PulsarTopology\"\
-      \n      \"flag\": \"v1\"\n      \"name\": \"pulsar-topology\"\n      \"params\"\
-      :\n        \"admin_url\": \"http://pulsar:8080\"\n    - \"class\": \"trustgraph.bootstrap.initialisers.TemplateSeed\"\
+      cassandra_replication_factor\": 1\n    \"id\": \"config-svc\"\n    \"pubsub_backend\"\
+      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"\
+      trustgraph.flow.service.Processor\"\n  \"params\":\n    \"id\": \"flow-svc\"\
+      \n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_admin_url\": \"http://pulsar:8080\"\
+      \n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.cores.service.Processor\"\
+      \n  \"params\":\n    \"cassandra_replication_factor\": 1\n    \"id\": \"knowledge\"\
+      \n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
+      \n- \"class\": \"trustgraph.storage.knowledge.store.Processor\"\n  \"params\"\
+      :\n    \"cassandra_replication_factor\": 1\n    \"id\": \"kg-store\"\n    \"\
+      pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n\
+      - \"class\": \"trustgraph.metering.Processor\"\n  \"params\":\n    \"id\": \"\
+      metering\"\n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
+      \n- \"class\": \"trustgraph.metering.Processor\"\n  \"params\":\n    \"id\"\
+      : \"metering-rag\"\n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\"\
+      : \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.iam.service.Processor\"\
+      \n  \"params\":\n    \"bootstrap_mode\": \"token\"\n    \"cassandra_replication_factor\"\
+      : 1\n    \"id\": \"iam-svc\"\n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\"\
+      : \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.bootstrap.bootstrapper.Processor\"\
+      \n  \"params\":\n    \"id\": \"bootstrap\"\n    \"initialisers\":\n    - \"\
+      class\": \"trustgraph.bootstrap.initialisers.PulsarTopology\"\n      \"flag\"\
+      : \"v1\"\n      \"name\": \"pulsar-topology\"\n      \"params\":\n        \"\
+      admin_url\": \"http://pulsar:8080\"\n    - \"class\": \"trustgraph.bootstrap.initialisers.TemplateSeed\"\
       \n      \"flag\": \"v1\"\n      \"name\": \"template-seed\"\n      \"params\"\
       :\n        \"config_file\": \"/etc/trustgraph/template/config.json\"\n     \
       \   \"overwrite\": false\n    - \"class\": \"trustgraph.bootstrap.initialisers.WorkspaceInit\"\
@@ -1628,7 +1640,7 @@ items:
               secretKeyRef:
                 key: token
                 name: iam-bootstrap-token
-          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          image: docker.io/trustgraph/trustgraph-flow:2.5.16
           name: control
           resources:
             limits:
@@ -1732,15 +1744,15 @@ items:
           - pulsar://pulsar:6650
           - --log-level
           - INFO
-          image: docker.io/trustgraph/trustgraph-unstructured:2.4.29
+          image: docker.io/trustgraph/trustgraph-unstructured:2.5.16
           name: document-decoder
           resources:
             limits:
               cpu: '0.5'
-              memory: 512M
+              memory: 1400M
             requests:
               cpu: '0.1'
-              memory: 512M
+              memory: 1400M
         enableServiceLinks: false
         volumes: []
 - apiVersion: v1
@@ -1795,7 +1807,7 @@ items:
           - INFO
           - -c
           - /etc/trustgraph/launch.yaml
-          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          image: docker.io/trustgraph/trustgraph-flow:2.5.16
           name: embeddings
           resources:
             limits:
@@ -2865,7 +2877,7 @@ items:
           - INFO
           - -c
           - /etc/trustgraph/launch.yaml
-          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          image: docker.io/trustgraph/trustgraph-flow:2.5.16
           name: ingest
           resources:
             limits:
@@ -2897,25 +2909,14 @@ items:
 - apiVersion: v1
   data:
     local-config.yaml: "auth_enabled: false\n\nserver:\n  http_listen_port: 3100\n\
-      \  grpc_listen_port: 9096\n  log_level: debug\n  grpc_server_max_concurrent_streams:\
-      \ 1000\n\ncommon:\n  instance_addr: 127.0.0.1\n  path_prefix: /tmp/loki\n  storage:\n\
-      \    filesystem:\n      chunks_directory: /tmp/loki/chunks\n      rules_directory:\
-      \ /tmp/loki/rules\n  replication_factor: 1\n  ring:\n    kvstore:\n      store:\
-      \ inmemory\n\nquery_range:\n  results_cache:\n    cache:\n      embedded_cache:\n\
-      \        enabled: true\n        max_size_mb: 100\n\nlimits_config:\n  metric_aggregation_enabled:\
-      \ true\n\nschema_config:\n  configs:\n    - from: 2020-10-24\n      store: tsdb\n\
-      \      object_store: filesystem\n      schema: v13\n      index:\n        prefix:\
-      \ index_\n        period: 24h\n\npattern_ingester:\n  enabled: true\n  metric_aggregation:\n\
-      \    loki_address: localhost:3100\n\nruler:\n  alertmanager_url: http://localhost:9093\n\
-      \nfrontend:\n  encoding: protobuf\n\n# By default, Loki will send anonymous,\
-      \ but uniquely-identifiable usage and configuration\n# analytics to Grafana\
-      \ Labs. These statistics are sent to https://stats.grafana.org/\n#\n# Statistics\
-      \ help us better understand how Loki is used, and they show us performance\n\
-      # levels for most users. This helps us prioritize features and documentation.\n\
-      # For more information on what's sent, look at\n# https://github.com/grafana/loki/blob/main/pkg/analytics/stats.go\n\
-      # Refer to the buildReport method to see what goes into a report.\n#\n# If you\
-      \ would like to disable reporting, uncomment the following lines:\nanalytics:\n\
-      \  reporting_enabled: false\n"
+      \ncommon:\n  instance_addr: 127.0.0.1\n  path_prefix: /loki\n  storage:\n  \
+      \  filesystem:\n      chunks_directory: /loki/chunks\n      rules_directory:\
+      \ /loki/rules\n  replication_factor: 1\n  ring:\n    kvstore:\n      store:\
+      \ inmemory\n\ningester:\n  lifecycler:\n    join_after: 2s\n\nschema_config:\n\
+      \  configs:\n    - from: 2020-10-24\n      store: tsdb\n      object_store:\
+      \ filesystem\n      schema: v13\n      index:\n        prefix: index_\n    \
+      \    period: 24h\n\nruler:\n  alertmanager_url: http://localhost:9093\n\nanalytics:\n\
+      \  reporting_enabled: false\n\n"
   kind: ConfigMap
   metadata:
     name: loki-cfg
@@ -2957,11 +2958,11 @@ items:
             hostPort: 3100
           resources:
             limits:
-              cpu: '0.5'
-              memory: 256M
+              cpu: '1.0'
+              memory: 350M
             requests:
-              cpu: '0.1'
-              memory: 256M
+              cpu: '0.5'
+              memory: 350M
           volumeMounts:
           - mountPath: /etc/loki/
             name: loki-cfg
@@ -2989,6 +2990,54 @@ items:
       targetPort: 3100
     selector:
       app: loki
+- apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    labels:
+      app: mcp-server
+    name: mcp-server
+    namespace: trustgraph
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: mcp-server
+    template:
+      metadata:
+        labels:
+          app: mcp-server
+      spec:
+        containers:
+        - command:
+          - mcp-server
+          - --port
+          - '8000'
+          image: docker.io/trustgraph/trustgraph-mcp:2.5.16
+          name: mcp-server
+          ports:
+          - containerPort: 8000
+            hostPort: 8000
+          resources:
+            limits:
+              cpu: '0.5'
+              memory: 256M
+            requests:
+              cpu: '0.1'
+              memory: 256M
+        enableServiceLinks: false
+        volumes: []
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: mcp-server
+    namespace: trustgraph
+  spec:
+    ports:
+    - name: mcp
+      port: 8000
+      targetPort: 8000
+    selector:
+      app: mcp-server
 - apiVersion: v1
   data:
     prometheus.yml: "global:\n\n  scrape_interval:     15s # By default, scrape targets\
@@ -3012,7 +3061,7 @@ items:
       \n  - job_name: 'text-completion'\n    scrape_interval: 5s\n    static_configs:\n\
       \      - targets:\n        - 'text-completion:8000'\n\n  # TrustGraph services\
       \ standalone\n  - job_name: 'api-gateway'\n    scrape_interval: 5s\n    static_configs:\n\
-      \      - targets:\n        - 'api-gateway:8000'\n\n  - job_name: 'mcp-server'\n\
+      \      - targets:\n        - 'api-gateway-metrics:8000'\n\n  - job_name: 'mcp-server'\n\
       \    scrape_interval: 5s\n    static_configs:\n      - targets:\n        - 'mcp-server:8000'\n\
       \n  - job_name: 'document-decoder'\n    scrape_interval: 5s\n    static_configs:\n\
       \      - targets:\n        - 'document-decoder:8000'\n\n  # Non-Trustgraph services\n\
@@ -3492,7 +3541,7 @@ items:
           - INFO
           - -c
           - /etc/trustgraph/launch.yaml
-          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          image: docker.io/trustgraph/trustgraph-flow:2.5.16
           name: rag
           resources:
             limits:
@@ -3524,11 +3573,12 @@ items:
 - apiVersion: v1
   data:
     launch.yaml: "\"processors\":\n- \"class\": \"trustgraph.query.rows.cassandra.Processor\"\
-      \n  \"params\":\n    \"cassandra_host\": \"cassandra\"\n    \"id\": \"rows-query\"\
-      \n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
-      \n- \"class\": \"trustgraph.storage.rows.cassandra.Processor\"\n  \"params\"\
-      :\n    \"cassandra_host\": \"cassandra\"\n    \"id\": \"rows-write\"\n    \"\
-      pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\""
+      \n  \"params\":\n    \"cassandra_host\": \"cassandra\"\n    \"cassandra_replication_factor\"\
+      : 1\n    \"id\": \"rows-query\"\n    \"pubsub_backend\": \"pulsar\"\n    \"\
+      pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.storage.rows.cassandra.Processor\"\
+      \n  \"params\":\n    \"cassandra_host\": \"cassandra\"\n    \"cassandra_replication_factor\"\
+      : 1\n    \"id\": \"rows-write\"\n    \"pubsub_backend\": \"pulsar\"\n    \"\
+      pulsar_host\": \"pulsar://pulsar:6650\""
   kind: ConfigMap
   metadata:
     name: rows-launch-cfg
@@ -3557,15 +3607,15 @@ items:
           - INFO
           - -c
           - /etc/trustgraph/launch.yaml
-          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          image: docker.io/trustgraph/trustgraph-flow:2.5.16
           name: rows
           resources:
             limits:
               cpu: '0.5'
-              memory: 512M
+              memory: 768M
             requests:
               cpu: '0.1'
-              memory: 512M
+              memory: 768M
           volumeMounts:
           - mountPath: /etc/trustgraph/
             name: rows-launch-cfg
@@ -3635,7 +3685,7 @@ items:
               secretKeyRef:
                 key: openai-url
                 name: openai-credentials
-          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          image: docker.io/trustgraph/trustgraph-flow:2.5.16
           name: text-completion
           resources:
             limits:
@@ -3667,11 +3717,12 @@ items:
 - apiVersion: v1
   data:
     launch.yaml: "\"processors\":\n- \"class\": \"trustgraph.query.triples.cassandra.Processor\"\
-      \n  \"params\":\n    \"cassandra_host\": \"cassandra\"\n    \"id\": \"triples-query\"\
-      \n    \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\
-      \n- \"class\": \"trustgraph.storage.triples.cassandra.Processor\"\n  \"params\"\
-      :\n    \"cassandra_host\": \"cassandra\"\n    \"id\": \"triples-write\"\n  \
-      \  \"pubsub_backend\": \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\""
+      \n  \"params\":\n    \"cassandra_host\": \"cassandra\"\n    \"cassandra_replication_factor\"\
+      : 1\n    \"id\": \"triples-query\"\n    \"pubsub_backend\": \"pulsar\"\n   \
+      \ \"pulsar_host\": \"pulsar://pulsar:6650\"\n- \"class\": \"trustgraph.storage.triples.cassandra.Processor\"\
+      \n  \"params\":\n    \"cassandra_host\": \"cassandra\"\n    \"cassandra_replication_factor\"\
+      : 1\n    \"id\": \"triples-write\"\n    \"pubsub_backend\": \"pulsar\"\n   \
+      \ \"pulsar_host\": \"pulsar://pulsar:6650\""
   kind: ConfigMap
   metadata:
     name: triples-launch-cfg
@@ -3700,7 +3751,7 @@ items:
           - INFO
           - -c
           - /etc/trustgraph/launch.yaml
-          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          image: docker.io/trustgraph/trustgraph-flow:2.5.16
           name: triples
           resources:
             limits:
@@ -3747,7 +3798,7 @@ items:
           app: trustgraph-ui
       spec:
         containers:
-        - image: docker.io/trustgraph/trustgraph-ui:0.1.1
+        - image: docker.io/trustgraph/trustgraph-ui:0.2.7
           name: trustgraph-ui
           ports:
           - containerPort: 8888
@@ -3780,20 +3831,22 @@ items:
       : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
       : \"http://qdrant:6333\"\n- \"class\": \"trustgraph.storage.doc_embeddings.qdrant.Processor\"\
       \n  \"params\":\n    \"id\": \"doc-embeddings-write\"\n    \"pubsub_backend\"\
-      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
-      : \"http://qdrant:6333\"\n- \"class\": \"trustgraph.query.graph_embeddings.qdrant.Processor\"\
-      \n  \"params\":\n    \"id\": \"graph-embeddings-query\"\n    \"pubsub_backend\"\
-      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
-      : \"http://qdrant:6333\"\n- \"class\": \"trustgraph.storage.graph_embeddings.qdrant.Processor\"\
+      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"qdrant_replication_factor\"\
+      : 1\n    \"qdrant_shard_number\": 1\n    \"store_uri\": \"http://qdrant:6333\"\
+      \n- \"class\": \"trustgraph.query.graph_embeddings.qdrant.Processor\"\n  \"\
+      params\":\n    \"id\": \"graph-embeddings-query\"\n    \"pubsub_backend\": \"\
+      pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\":\
+      \ \"http://qdrant:6333\"\n- \"class\": \"trustgraph.storage.graph_embeddings.qdrant.Processor\"\
       \n  \"params\":\n    \"id\": \"graph-embeddings-write\"\n    \"pubsub_backend\"\
-      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
-      : \"http://qdrant:6333\"\n- \"class\": \"trustgraph.query.row_embeddings.qdrant.Processor\"\
-      \n  \"params\":\n    \"id\": \"row-embeddings-query\"\n    \"pubsub_backend\"\
-      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
-      : \"http://qdrant:6333\"\n- \"class\": \"trustgraph.storage.row_embeddings.qdrant.Processor\"\
-      \n  \"params\":\n    \"id\": \"row-embeddings-write\"\n    \"pubsub_backend\"\
-      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\"\
-      : \"http://qdrant:6333\""
+      : \"pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"qdrant_replication_factor\"\
+      : 1\n    \"qdrant_shard_number\": 1\n    \"store_uri\": \"http://qdrant:6333\"\
+      \n- \"class\": \"trustgraph.query.row_embeddings.qdrant.Processor\"\n  \"params\"\
+      :\n    \"id\": \"row-embeddings-query\"\n    \"pubsub_backend\": \"pulsar\"\n\
+      \    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"store_uri\": \"http://qdrant:6333\"\
+      \n- \"class\": \"trustgraph.storage.row_embeddings.qdrant.Processor\"\n  \"\
+      params\":\n    \"id\": \"row-embeddings-write\"\n    \"pubsub_backend\": \"\
+      pulsar\"\n    \"pulsar_host\": \"pulsar://pulsar:6650\"\n    \"qdrant_replication_factor\"\
+      : 1\n    \"qdrant_shard_number\": 1\n    \"store_uri\": \"http://qdrant:6333\""
   kind: ConfigMap
   metadata:
     name: vector-store-cfg
@@ -3822,7 +3875,7 @@ items:
           - INFO
           - -c
           - /etc/trustgraph/launch.yaml
-          image: docker.io/trustgraph/trustgraph-flow:2.4.29
+          image: docker.io/trustgraph/trustgraph-flow:2.5.16
           name: vector-store
           resources:
             limits:


### PR DESCRIPTION
## Summary

- Add Nginx Gateway Fabric + cert-manager for public HTTPS access to TrustGraph UI and Grafana via Gateway API with host-based routing and automatic Let's Encrypt TLS certificates
- Split monolithic `index.ts` into `cluster.ts`, `application.ts`, `cert-manager.ts`, and `gateway.ts` modules
- Upgrade to TrustGraph 2.5.16; add missing `cassandra`, `garage`, `mcp-server` components and memory overrides to `config.json`
- Update README with gateway/DNS documentation, fix stale references (AKS, workbench-ui, version)
- Update and extend tests for new config values and gateway resources

## Configuration

Three new required Pulumi config values:
- `trustgraph-scaleway:domain` — hostname for TrustGraph UI
- `trustgraph-scaleway:grafana-domain` — hostname for Grafana
- `trustgraph-scaleway:letsencrypt-email` — email for Let's Encrypt registration

After deploy, point DNS A records for both domains at the Nginx Gateway Fabric LoadBalancer IP.

## Test plan

- [x] `npm test` — all 11 tests pass (config + infrastructure)
- [x] `pulumi up` — deploy and verify gateway resources created
- [x] Verify DNS + TLS cert provisioning with real domains
- [x] Verify TrustGraph UI accessible via HTTPS
- [x] Verify Grafana accessible via HTTPS
